### PR TITLE
Refactor session runtime, settings data seams, STT adapters, and ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ playwright-report/
 npm-debug.*
 yarn-debug.*
 yarn-error.*
+
+# Sandcastle agent work/logs
+.sandcastle/

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -16,14 +16,12 @@ import { DisplaySection } from '../src/settings/renderers/DisplaySection';
 import { FilesSection } from '../src/settings/renderers/FilesSection';
 import { VoiceSection } from '../src/settings/renderers/VoiceSection';
 import { createStyles } from '../src/settings/styles';
+import { useVoiceSettingsCategory } from '../src/settings/voice-settings-category';
 import {
   createAppDataWriteToken,
-  getAppDataItem,
   isAppDataWriteTokenCurrent,
   resetStoredAppData,
-  setAppDataItem,
 } from '../src/storage/app-data';
-import { DEFAULT_STT_SETTINGS, STT_SETTINGS_KEY, STTSettings } from '../src/stt/index';
 
 function confirmDeleteAllData(): Promise<boolean> {
   const message = 'This deletes uploads, pasted content, AI parsed files, saved settings, API keys, source URLs, cached SRD data, and the current session on this device.';
@@ -52,16 +50,21 @@ export default function SettingsScreen() {
   const styles = useMemo(() => createStyles(C, isWide), [C, isWide]);
 
   const [category, setCategory] = useState<Category>('display');
-  const [sttSettings, setSttSettings] = useState<STTSettings>(DEFAULT_STT_SETTINGS);
-  const [voiceSaved, setVoiceSaved] = useState(false);
   const [dataSaved, setDataSaved] = useState(false);
   const [deleteAllPending, setDeleteAllPending] = useState(false);
   const [deleteAllStatus, setDeleteAllStatus] = useState('');
   const { cardSize, setCardSize, colorScheme, setColorScheme, resetUISettings } = useUISettings();
   const { settings: ds, update: updateDs, bumpUploads, reset: resetDataSources } = useDataSources();
   const { stop: stopSession } = useSession();
+  const {
+    sttSettings,
+    setSttSettings,
+    saveVoice,
+    voiceSaved,
+    isWebSpeech,
+    resetVoiceSettings,
+  } = useVoiceSettingsCategory();
   const [dsLocal, setDsLocal] = useState<DataSourcesSettings>(ds);
-  const voiceSavedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dataSavedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [uploads, setUploads] = useState<UploadedFile[]>([]);
@@ -78,33 +81,13 @@ export default function SettingsScreen() {
   }, [bumpUploads]);
 
   useEffect(() => {
-    const token = createAppDataWriteToken();
-    getAppDataItem(STT_SETTINGS_KEY, token).then((raw) => {
-      if (raw) {
-        try {
-          setSttSettings({ ...DEFAULT_STT_SETTINGS, ...(JSON.parse(raw) as Partial<STTSettings>) });
-        } catch (parseErr) {
-          console.warn('[dnd-ref] Failed to parse STT settings:', parseErr);
-        }
-      }
-    });
     refreshUploads();
     return () => {
-      if (voiceSavedTimer.current) clearTimeout(voiceSavedTimer.current);
       if (dataSavedTimer.current) clearTimeout(dataSavedTimer.current);
     };
   }, [refreshUploads]);
 
   useEffect(() => { setDsLocal(ds); }, [ds]);
-
-  const saveVoice = async () => {
-    const token = createAppDataWriteToken();
-    const saved = await setAppDataItem(STT_SETTINGS_KEY, JSON.stringify(sttSettings), { token });
-    if (!saved || !isAppDataWriteTokenCurrent(token)) return;
-    setVoiceSaved(true);
-    if (voiceSavedTimer.current) clearTimeout(voiceSavedTimer.current);
-    voiceSavedTimer.current = setTimeout(() => setVoiceSaved(false), 2000);
-  };
 
   const saveData = async () => {
     await updateDs(dsLocal);
@@ -157,14 +140,13 @@ export default function SettingsScreen() {
       await resetStoredAppData({ beforeClear: waitForUploadMutations });
       resetDataSources();
       resetUISettings();
-      setSttSettings(DEFAULT_STT_SETTINGS);
+      resetVoiceSettings();
       setDsLocal(createDefaultDataSourceSettings());
       setUploads([]);
       setPasteFileName('');
       setPasteContent('');
       setAiContent('');
       setAiResult('');
-      setVoiceSaved(false);
       setDataSaved(false);
       setDeleteAllStatus('All local app data was deleted.');
     } catch (e: unknown) {
@@ -195,8 +177,6 @@ export default function SettingsScreen() {
       setAiParsing(false);
     }
   };
-
-  const isWebSpeech = Platform.OS === 'web';
 
   const renderContent = () => {
     switch (category) {

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,15 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Alert, Platform, ScrollView, Text, TouchableOpacity, View, useWindowDimensions,
-} from 'react-native';
+import { ScrollView, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 
 import { Ionicon } from '../src/components/Ionicon';
 import { createDefaultDataSourceSettings, type DataSourcesSettings, useDataSources } from '../src/context/data-sources';
 import { useSession } from '../src/context/session';
 import { useColors, useUISettings } from '../src/context/ui-settings';
 import { parseWithAI } from '../src/entities/ai-parser';
-import { UploadedFile, addUpload, getUploads, removeUpload } from '../src/entities/providers/file-upload';
 import { Category, CATEGORIES } from '../src/settings/constants';
+import { useFilesSettingsCategory } from '../src/settings/files-settings-category';
 import { AISection } from '../src/settings/renderers/AISection';
 import { DataSection } from '../src/settings/renderers/DataSection';
 import { DisplaySection } from '../src/settings/renderers/DisplaySection';
@@ -20,28 +18,7 @@ import { useVoiceSettingsCategory } from '../src/settings/voice-settings-categor
 import {
   createAppDataWriteToken,
   isAppDataWriteTokenCurrent,
-  resetStoredAppData,
 } from '../src/storage/app-data';
-
-function confirmDeleteAllData(): Promise<boolean> {
-  const message = 'This deletes uploads, pasted content, AI parsed files, saved settings, API keys, source URLs, cached SRD data, and the current session on this device.';
-
-  if (Platform.OS === 'web' && typeof window !== 'undefined') {
-    return Promise.resolve(window.confirm(`Delete all local app data?\n\n${message}`));
-  }
-
-  return new Promise((resolve) => {
-    Alert.alert(
-      'Delete all local app data?',
-      message,
-      [
-        { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
-        { text: 'Delete All Data', style: 'destructive', onPress: () => resolve(true) },
-      ],
-      { cancelable: true, onDismiss: () => resolve(false) },
-    );
-  });
-}
 
 export default function SettingsScreen() {
   const C = useColors();
@@ -51,8 +28,6 @@ export default function SettingsScreen() {
 
   const [category, setCategory] = useState<Category>('display');
   const [dataSaved, setDataSaved] = useState(false);
-  const [deleteAllPending, setDeleteAllPending] = useState(false);
-  const [deleteAllStatus, setDeleteAllStatus] = useState('');
   const { cardSize, setCardSize, colorScheme, setColorScheme, resetUISettings } = useUISettings();
   const { settings: ds, update: updateDs, bumpUploads, reset: resetDataSources } = useDataSources();
   const { stop: stopSession } = useSession();
@@ -66,26 +41,29 @@ export default function SettingsScreen() {
   } = useVoiceSettingsCategory();
   const [dsLocal, setDsLocal] = useState<DataSourcesSettings>(ds);
   const dataSavedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const [uploads, setUploads] = useState<UploadedFile[]>([]);
-  const [removingUploadId, setRemovingUploadId] = useState<string | null>(null);
-  const [pasteFileName, setPasteFileName] = useState('');
-  const [pasteContent, setPasteContent] = useState('');
   const [aiContent, setAiContent] = useState('');
   const [aiParsing, setAiParsing] = useState(false);
   const [aiResult, setAiResult] = useState('');
 
-  const refreshUploads = useCallback(async () => {
-    setUploads(await getUploads());
-    bumpUploads();
-  }, [bumpUploads]);
+  const resetAfterDeleteAll = useCallback(() => {
+    resetDataSources();
+    resetUISettings();
+    resetVoiceSettings();
+    setDsLocal(createDefaultDataSourceSettings());
+    setAiContent('');
+    setAiResult('');
+    setDataSaved(false);
+  }, [resetDataSources, resetUISettings, resetVoiceSettings]);
 
-  useEffect(() => {
-    refreshUploads();
-    return () => {
-      if (dataSavedTimer.current) clearTimeout(dataSavedTimer.current);
-    };
-  }, [refreshUploads]);
+  const filesCategory = useFilesSettingsCategory({
+    bumpUploads,
+    stopSession,
+    onDeleteAllDataReset: resetAfterDeleteAll,
+  });
+
+  useEffect(() => () => {
+    if (dataSavedTimer.current) clearTimeout(dataSavedTimer.current);
+  }, []);
 
   useEffect(() => { setDsLocal(ds); }, [ds]);
 
@@ -94,66 +72,6 @@ export default function SettingsScreen() {
     setDataSaved(true);
     if (dataSavedTimer.current) clearTimeout(dataSavedTimer.current);
     dataSavedTimer.current = setTimeout(() => setDataSaved(false), 2000);
-  };
-
-  const pickFilesWeb = () => {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.multiple = true;
-    input.accept = '.md,.txt,.json';
-    input.onchange = async () => {
-      const files = Array.from(input.files ?? []);
-      input.onchange = null;
-      await Promise.all(files.map((f) => f.text().then((text) => addUpload(f.name, text))));
-      await refreshUploads();
-    };
-    input.click();
-  };
-
-  const handlePasteAdd = async () => {
-    const name = pasteFileName.trim() || 'Pasted Content.md';
-    if (!pasteContent.trim()) return;
-    await addUpload(name, pasteContent);
-    setPasteFileName('');
-    setPasteContent('');
-    await refreshUploads();
-  };
-
-  const handleDeleteUpload = async (id: string) => {
-    setRemovingUploadId(id);
-    try {
-      await removeUpload(id);
-      await refreshUploads();
-    } finally {
-      setRemovingUploadId((current) => (current === id ? null : current));
-    }
-  };
-
-  const handleDeleteAllData = async () => {
-    const confirmed = await confirmDeleteAllData();
-    if (!confirmed) return;
-
-    setDeleteAllPending(true);
-    setDeleteAllStatus('');
-    try {
-      stopSession();
-      await resetStoredAppData();
-      resetDataSources();
-      resetUISettings();
-      resetVoiceSettings();
-      setDsLocal(createDefaultDataSourceSettings());
-      setUploads([]);
-      setPasteFileName('');
-      setPasteContent('');
-      setAiContent('');
-      setAiResult('');
-      setDataSaved(false);
-      setDeleteAllStatus('All local app data was deleted.');
-    } catch (e: unknown) {
-      setDeleteAllStatus(`Delete failed: ${e instanceof Error ? e.message : String(e)}`);
-    } finally {
-      setDeleteAllPending(false);
-    }
   };
 
   const handleAIParse = async () => {
@@ -165,9 +83,7 @@ export default function SettingsScreen() {
       const entities = await parseWithAI(aiContent, dsLocal.aiApiKey);
       if (!isAppDataWriteTokenCurrent(token)) return;
       const name = `AI Parsed ${new Date().toLocaleDateString()}.json`;
-      await addUpload(name, JSON.stringify(entities));
-      if (!isAppDataWriteTokenCurrent(token)) return;
-      await refreshUploads();
+      await filesCategory.saveUpload(name, JSON.stringify(entities));
       if (!isAppDataWriteTokenCurrent(token)) return;
       setAiResult(`Found ${entities.length} entities. Saved as "${name}".`);
       setAiContent('');
@@ -189,18 +105,18 @@ export default function SettingsScreen() {
       case 'files':
         return (
           <FilesSection
-            uploads={uploads}
-            removingUploadId={removingUploadId}
-            pasteFileName={pasteFileName}
-            setPasteFileName={setPasteFileName}
-            pasteContent={pasteContent}
-            setPasteContent={setPasteContent}
-            pickFilesWeb={pickFilesWeb}
-            handlePasteAdd={handlePasteAdd}
-            handleDeleteUpload={handleDeleteUpload}
-            handleDeleteAllData={handleDeleteAllData}
-            deleteAllPending={deleteAllPending}
-            deleteAllStatus={deleteAllStatus}
+            uploads={filesCategory.uploads}
+            removingUploadId={filesCategory.removingUploadId}
+            pasteFileName={filesCategory.pasteFileName}
+            setPasteFileName={filesCategory.setPasteFileName}
+            pasteContent={filesCategory.pasteContent}
+            setPasteContent={filesCategory.setPasteContent}
+            pickFilesWeb={filesCategory.pickFilesWeb}
+            handlePasteAdd={filesCategory.handlePasteAdd}
+            handleDeleteUpload={filesCategory.handleDeleteUpload}
+            handleDeleteAllData={filesCategory.handleDeleteAllData}
+            deleteAllPending={filesCategory.deleteAllPending}
+            deleteAllStatus={filesCategory.deleteAllStatus}
             styles={styles}
           />
         );

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -8,7 +8,7 @@ import { createDefaultDataSourceSettings, type DataSourcesSettings, useDataSourc
 import { useSession } from '../src/context/session';
 import { useColors, useUISettings } from '../src/context/ui-settings';
 import { parseWithAI } from '../src/entities/ai-parser';
-import { UploadedFile, addUpload, getUploads, removeUpload, waitForUploadMutations } from '../src/entities/providers/file-upload';
+import { UploadedFile, addUpload, getUploads, removeUpload } from '../src/entities/providers/file-upload';
 import { Category, CATEGORIES } from '../src/settings/constants';
 import { AISection } from '../src/settings/renderers/AISection';
 import { DataSection } from '../src/settings/renderers/DataSection';
@@ -154,7 +154,7 @@ export default function SettingsScreen() {
     setDeleteAllStatus('');
     try {
       stopSession();
-      await resetStoredAppData({ beforeClear: waitForUploadMutations });
+      await resetStoredAppData();
       resetDataSources();
       resetUISettings();
       setSttSettings(DEFAULT_STT_SETTINGS);

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -4,7 +4,7 @@ import {
 } from 'react-native';
 
 import { Ionicon } from '../src/components/Ionicon';
-import { DEFAULT_DATA_SOURCES_SETTINGS, DataSourcesSettings, useDataSources } from '../src/context/data-sources';
+import { createDefaultDataSourceSettings, type DataSourcesSettings, useDataSources } from '../src/context/data-sources';
 import { useSession } from '../src/context/session';
 import { useColors, useUISettings } from '../src/context/ui-settings';
 import { parseWithAI } from '../src/entities/ai-parser';
@@ -158,7 +158,7 @@ export default function SettingsScreen() {
       resetDataSources();
       resetUISettings();
       setSttSettings(DEFAULT_STT_SETTINGS);
-      setDsLocal(DEFAULT_DATA_SOURCES_SETTINGS);
+      setDsLocal(createDefaultDataSourceSettings());
       setUploads([]);
       setPasteFileName('');
       setPasteContent('');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "proxy:dev": "wrangler dev --config workers/cors-proxy/wrangler.toml",
     "proxy:deploy": "wrangler deploy --config workers/cors-proxy/wrangler.toml",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, ScrollView, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 
-import { CardState, useSession } from '../context/session';
+import { useSession } from '../context/session';
 import { useColors, useUISettings } from '../context/ui-settings';
 import { computeReferenceCardLayout, type ReferenceCardPosition } from '../reference-card-layout';
 import { Colors, F } from '../theme';

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -1,52 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, ScrollView, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 
-import { EntityCard } from './EntityCard';
 import { CardState, useSession } from '../context/session';
-import { CARD_SIZE_CONFIGS, useColors, useUISettings } from '../context/ui-settings';
+import { useColors, useUISettings } from '../context/ui-settings';
+import { computeReferenceCardLayout, type ReferenceCardPosition } from '../reference-card-layout';
 import { Colors, F } from '../theme';
+import { EntityCard } from './EntityCard';
 
-const GRID_PAD = 5;
-const CARD_MARGIN = 5;
-const MIN_CARD_WIDTH = 230;
-const MAX_CARD_WIDTH = 380;
-
-interface CardPos { x: number; y: number }
 interface AnimPair { left: Animated.Value; top: Animated.Value }
-
-function computePositions(
-  cards: CardState[],
-  heights: Record<string, number>,
-  columns: number,
-  cardWidth: number,
-  xOffset: number,
-): { positions: Record<string, CardPos>; totalHeight: number } {
-  const colWidth = cardWidth + 2 * CARD_MARGIN;
-
-  const rowHeights: number[] = [];
-  for (let i = 0; i < cards.length; i++) {
-    const row = Math.floor(i / columns);
-    const h = heights[cards[i].instanceId] ?? 200;
-    rowHeights[row] = Math.max(rowHeights[row] ?? 0, h);
-  }
-
-  const rowY: number[] = [GRID_PAD];
-  for (let r = 0; r < rowHeights.length; r++) {
-    rowY[r + 1] = rowY[r] + rowHeights[r];
-  }
-
-  const positions: Record<string, CardPos> = {};
-  for (let i = 0; i < cards.length; i++) {
-    const col = i % columns;
-    const row = Math.floor(i / columns);
-    positions[cards[i].instanceId] = {
-      x: xOffset + GRID_PAD + col * colWidth,
-      y: rowY[row],
-    };
-  }
-
-  return { positions, totalHeight: rowY[rowHeights.length] + GRID_PAD };
-}
 
 const SPRING_CONFIG = { friction: 22, tension: 55, useNativeDriver: false } as const;
 
@@ -55,23 +16,25 @@ export function CardGrid() {
   const { cards, status, pin, unpin, dismiss } = useSession();
   const { cardSize } = useUISettings();
   const { width, height: winHeight } = useWindowDimensions();
-  const config = CARD_SIZE_CONFIGS[cardSize];
-  const preferredColumns = width > winHeight ? config.landscapeCols : config.portraitCols;
-  const readableColumns = Math.max(1, Math.floor((width - 2 * GRID_PAD) / (MIN_CARD_WIDTH + 2 * CARD_MARGIN)));
-  const columns = Math.min(preferredColumns, readableColumns);
-  const gridWidth = Math.min(width, columns * (MAX_CARD_WIDTH + 2 * CARD_MARGIN) + 2 * GRID_PAD);
-  const xOffset = Math.max(0, (width - gridWidth) / 2);
-  const cardWidth = (gridWidth - 2 * GRID_PAD) / columns - 2 * CARD_MARGIN;
   const styles = useMemo(() => createStyles(C), [C]);
 
   const [cardHeights, setCardHeights] = useState<Record<string, number>>({});
 
   const animRef = useRef<Record<string, AnimPair>>({});
-  const prevPos = useRef<Record<string, CardPos>>({});
+  const prevPos = useRef<Record<string, ReferenceCardPosition>>({});
 
-  const { positions: targets, totalHeight } = useMemo(
-    () => computePositions(cards, cardHeights, columns, cardWidth, xOffset),
-    [cards, cardHeights, columns, cardWidth, xOffset],
+  const {
+    cardWidth,
+    positions: targets,
+    totalHeight,
+  } = useMemo(
+    () => computeReferenceCardLayout({
+      cards,
+      measuredHeights: cardHeights,
+      viewport: { width, height: winHeight },
+      cardSize,
+    }),
+    [cards, cardHeights, width, winHeight, cardSize],
   );
 
   for (const [id, pos] of Object.entries(targets)) {

--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Animated, Image, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import type { CardState } from '../context/session';
+import type { CardState } from '../context/session-types';
 import { CARD_SIZE_CONFIGS, useColors, useUISettings } from '../context/ui-settings';
 import { deriveEntityCardPresentation } from '../entity-card-presentation';
 import { Colors, F, typeAccent } from '../theme';
@@ -17,7 +17,7 @@ interface Props {
 
 export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
   const C = useColors();
-  const accentColor = typeAccent(card.entity.type, C);
+  const entityAccentColor = typeAccent(card.entity.type, C);
   const fadeIn = useRef(new Animated.Value(0)).current;
   const slideUp = useRef(new Animated.Value(8)).current;
 
@@ -26,12 +26,20 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
 
   const styles = useMemo(() => createStyles(C), [C]);
   const presentation = useMemo(
-    () => deriveEntityCardPresentation({ card, accentColor }),
-    [card, accentColor],
+    () => deriveEntityCardPresentation({ card, accentColor: entityAccentColor }),
+    [card, entityAccentColor],
   );
-  const { pinned } = presentation;
-  const color = presentation.accentColor;
-  const onTogglePin = presentation.actions.pinToggle.kind === 'unpin' ? onUnpin : onPin;
+  const {
+    actions: { dismiss: dismissAction, pinToggle: pinToggleAction },
+    accentColor,
+    bulletMarker,
+    imageUri,
+    name,
+    pinned,
+    summaryBullets,
+    typeLabel,
+  } = presentation;
+  const onTogglePin = pinToggleAction.kind === 'unpin' ? onUnpin : onPin;
 
   useEffect(() => {
     const anim = Animated.parallel([
@@ -45,7 +53,7 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
   const webStyles = Platform.OS === 'web'
     ? {
         boxShadow: pinned
-          ? `0 0 0 1px ${color}48, 0 6px 28px ${color}20, 0 2px 8px #00000040`
+          ? `0 0 0 1px ${accentColor}48, 0 6px 28px ${accentColor}20, 0 2px 8px #00000040`
           : '0 2px 12px #00000030',
       }
     : {};
@@ -56,54 +64,50 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
         styles.card,
         { width, opacity: fadeIn, transform: [{ translateY: slideUp }] },
         pinned && styles.cardPinned,
-        pinned && { borderColor: color + '40', borderLeftColor: color, borderLeftWidth: 3 },
+        pinned && { borderColor: accentColor + '40', borderLeftColor: accentColor, borderLeftWidth: 3 },
         webStyles as object,
       ]}
     >
-      <View style={[styles.topStrip, { backgroundColor: color }]} />
+      <View style={[styles.topStrip, { backgroundColor: accentColor }]} />
 
-      <View style={[styles.header, { backgroundColor: color + (pinned ? '12' : '0b') }]}>
+      <View style={[styles.header, { backgroundColor: accentColor + (pinned ? '12' : '0b') }]}>
         <View style={styles.headerTop}>
           <View style={styles.headerLeft}>
             <Text
               style={[styles.name, { fontSize: 14 * fontScale, lineHeight: 20 * fontScale }]}
               numberOfLines={2}
             >
-              {presentation.name}
+              {name}
             </Text>
-            <Text style={[styles.typeLabel, { color: color + 'b0', fontSize: 8 * fontScale }]}>
-              {presentation.typeLabel}
+            <Text style={[styles.typeLabel, { color: accentColor + 'b0', fontSize: 8 * fontScale }]}>
+              {typeLabel}
             </Text>
           </View>
           <View style={styles.headerRight}>
             <View style={styles.actions}>
-              {presentation.actions.pinToggle.available && (
-                <TouchableOpacity
-                  onPress={onTogglePin}
-                  accessibilityLabel={presentation.actions.pinToggle.accessibilityLabel}
-                  hitSlop={{ top: 12, bottom: 12, left: 12, right: 6 }}
-                >
-                  <Ionicon
-                    name={presentation.actions.pinToggle.iconName}
-                    size={15 * fontScale}
-                    color={pinned ? color : C.textDim}
-                  />
-                </TouchableOpacity>
-              )}
-              {presentation.actions.dismiss.available && (
-                <TouchableOpacity
-                  onPress={onDismiss}
-                  accessibilityLabel={presentation.actions.dismiss.accessibilityLabel}
-                  hitSlop={{ top: 12, bottom: 12, left: 6, right: 12 }}
-                >
-                  <Ionicon name={presentation.actions.dismiss.iconName} size={14 * fontScale} color={C.textDim} />
-                </TouchableOpacity>
-              )}
+              <TouchableOpacity
+                onPress={onTogglePin}
+                accessibilityLabel={pinToggleAction.accessibilityLabel}
+                hitSlop={{ top: 12, bottom: 12, left: 12, right: 6 }}
+              >
+                <Ionicon
+                  name={pinToggleAction.iconName}
+                  size={15 * fontScale}
+                  color={pinned ? accentColor : C.textDim}
+                />
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={onDismiss}
+                accessibilityLabel={dismissAction.accessibilityLabel}
+                hitSlop={{ top: 12, bottom: 12, left: 6, right: 12 }}
+              >
+                <Ionicon name={dismissAction.iconName} size={14 * fontScale} color={C.textDim} />
+              </TouchableOpacity>
             </View>
-            {presentation.imageUri && (
+            {imageUri && (
               <Image
-                source={{ uri: presentation.imageUri }}
-                style={[styles.portrait, { borderColor: color + '35' }]}
+                source={{ uri: imageUri }}
+                style={[styles.portrait, { borderColor: accentColor + '35' }]}
                 resizeMode="cover"
               />
             )}
@@ -111,13 +115,13 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
         </View>
       </View>
 
-      <View style={[styles.divider, { backgroundColor: color + '22' }]} />
+      <View style={[styles.divider, { backgroundColor: accentColor + '22' }]} />
 
       <View style={styles.bullets}>
-        {presentation.summaryBullets.map((bullet, i) => (
+        {summaryBullets.map((bullet, i) => (
           <View key={i} style={styles.bulletRow}>
-            <Text style={[styles.bulletMark, { color: color + 'aa', fontSize: 11 * fontScale, lineHeight: 18 * fontScale }]}>
-              {presentation.bulletMarker}
+            <Text style={[styles.bulletMark, { color: accentColor + 'aa', fontSize: 11 * fontScale, lineHeight: 18 * fontScale }]}>
+              {bulletMarker}
             </Text>
             <Text style={[styles.bulletText, { fontSize: 12 * fontScale, lineHeight: 18 * fontScale }]}>
               {bullet}

--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -1,18 +1,11 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Animated, Image, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import { Ionicon } from './Ionicon';
-import { CardState } from '../context/session';
+import type { CardState } from '../context/session';
 import { CARD_SIZE_CONFIGS, useColors, useUISettings } from '../context/ui-settings';
+import { deriveEntityCardPresentation } from '../entity-card-presentation';
 import { Colors, F, typeAccent } from '../theme';
-
-function parseBullets(summary: string): string[] {
-  return summary
-    .split(/(?<=[.!])\s+/)
-    .map((s) => s.replace(/[.!]$/, '').trim())
-    .filter((s) => s.length > 0)
-    .slice(0, 5);
-}
+import { Ionicon } from './Ionicon';
 
 interface Props {
   card: CardState;
@@ -23,9 +16,8 @@ interface Props {
 }
 
 export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
-  const { entity, pinned } = card;
   const C = useColors();
-  const color = typeAccent(entity.type, C);
+  const accentColor = typeAccent(card.entity.type, C);
   const fadeIn = useRef(new Animated.Value(0)).current;
   const slideUp = useRef(new Animated.Value(8)).current;
 
@@ -33,6 +25,13 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
   const { fontScale } = CARD_SIZE_CONFIGS[cardSize];
 
   const styles = useMemo(() => createStyles(C), [C]);
+  const presentation = useMemo(
+    () => deriveEntityCardPresentation({ card, accentColor }),
+    [card, accentColor],
+  );
+  const { pinned } = presentation;
+  const color = presentation.accentColor;
+  const onTogglePin = presentation.actions.pinToggle.kind === 'unpin' ? onUnpin : onPin;
 
   useEffect(() => {
     const anim = Animated.parallel([
@@ -42,8 +41,6 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
     anim.start();
     return () => anim.stop();
   }, []);
-
-  const bullets = useMemo(() => parseBullets(entity.summary), [entity.summary]);
 
   const webStyles = Platform.OS === 'web'
     ? {
@@ -72,36 +69,40 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
               style={[styles.name, { fontSize: 14 * fontScale, lineHeight: 20 * fontScale }]}
               numberOfLines={2}
             >
-              {entity.name}
+              {presentation.name}
             </Text>
             <Text style={[styles.typeLabel, { color: color + 'b0', fontSize: 8 * fontScale }]}>
-              {entity.type.toUpperCase()}
+              {presentation.typeLabel}
             </Text>
           </View>
           <View style={styles.headerRight}>
             <View style={styles.actions}>
-              <TouchableOpacity
-                onPress={pinned ? onUnpin : onPin}
-                accessibilityLabel={pinned ? 'Unpin' : 'Pin'}
-                hitSlop={{ top: 12, bottom: 12, left: 12, right: 6 }}
-              >
-                <Ionicon
-                  name={pinned ? 'bookmark' : 'bookmark-outline'}
-                  size={15 * fontScale}
-                  color={pinned ? color : C.textDim}
-                />
-              </TouchableOpacity>
-              <TouchableOpacity
-                onPress={onDismiss}
-                accessibilityLabel="Dismiss"
-                hitSlop={{ top: 12, bottom: 12, left: 6, right: 12 }}
-              >
-                <Ionicon name="close" size={14 * fontScale} color={C.textDim} />
-              </TouchableOpacity>
+              {presentation.actions.pinToggle.available && (
+                <TouchableOpacity
+                  onPress={onTogglePin}
+                  accessibilityLabel={presentation.actions.pinToggle.accessibilityLabel}
+                  hitSlop={{ top: 12, bottom: 12, left: 12, right: 6 }}
+                >
+                  <Ionicon
+                    name={presentation.actions.pinToggle.iconName}
+                    size={15 * fontScale}
+                    color={pinned ? color : C.textDim}
+                  />
+                </TouchableOpacity>
+              )}
+              {presentation.actions.dismiss.available && (
+                <TouchableOpacity
+                  onPress={onDismiss}
+                  accessibilityLabel={presentation.actions.dismiss.accessibilityLabel}
+                  hitSlop={{ top: 12, bottom: 12, left: 6, right: 12 }}
+                >
+                  <Ionicon name={presentation.actions.dismiss.iconName} size={14 * fontScale} color={C.textDim} />
+                </TouchableOpacity>
+              )}
             </View>
-            {entity.image && (
+            {presentation.imageUri && (
               <Image
-                source={{ uri: entity.image }}
+                source={{ uri: presentation.imageUri }}
                 style={[styles.portrait, { borderColor: color + '35' }]}
                 resizeMode="cover"
               />
@@ -113,10 +114,10 @@ export function EntityCard({ card, width, onPin, onUnpin, onDismiss }: Props) {
       <View style={[styles.divider, { backgroundColor: color + '22' }]} />
 
       <View style={styles.bullets}>
-        {bullets.map((bullet, i) => (
+        {presentation.summaryBullets.map((bullet, i) => (
           <View key={i} style={styles.bulletRow}>
             <Text style={[styles.bulletMark, { color: color + 'aa', fontSize: 11 * fontScale, lineHeight: 18 * fontScale }]}>
-              {'>'}
+              {presentation.bulletMarker}
             </Text>
             <Text style={[styles.bulletText, { fontSize: 12 * fontScale, lineHeight: 18 * fontScale }]}>
               {bullet}

--- a/src/context/card-stack.ts
+++ b/src/context/card-stack.ts
@@ -4,20 +4,35 @@ import type { CardState } from './session-types';
 export const MAX_CARDS = 6;
 
 export function extractCard(cards: CardState[], instanceId: string): [CardState, CardState[]] | null {
-  const card = cards.find((c) => c.instanceId === instanceId);
+  const card = cards.find((candidate) => candidate.instanceId === instanceId);
   if (!card) return null;
-  return [card, cards.filter((c) => c.instanceId !== instanceId)];
+
+  const remainingCards = cards.filter((candidate) => candidate.instanceId !== instanceId);
+  return [card, remainingCards];
 }
 
 export function buildCardIdSet(cards: CardState[]): Set<string> {
-  return new Set(cards.map((c) => c.entity.id));
+  return new Set(cards.map((card) => card.entity.id));
 }
 
 export function insertAfterPinned(cards: CardState[], card: CardState): CardState[] {
-  const lastPinnedIdx = cards.reduce((acc, c, i) => (c.pinned ? i : acc), -1);
-  const result = [...cards];
-  result.splice(lastPinnedIdx + 1, 0, card);
-  return result;
+  const lastPinnedIndex = cards.reduce((lastIndex, candidate, index) => {
+    if (!candidate.pinned) return lastIndex;
+    return index;
+  }, -1);
+  const nextCards = [...cards];
+  nextCards.splice(lastPinnedIndex + 1, 0, card);
+  return nextCards;
+}
+
+function findRightmostUnpinnedIndex(cards: CardState[]): number {
+  for (let index = cards.length - 1; index >= 0; index--) {
+    if (!cards[index].pinned) {
+      return index;
+    }
+  }
+
+  return -1;
 }
 
 export function addCard(cards: CardState[], entity: Entity): CardState[] {
@@ -25,34 +40,31 @@ export function addCard(cards: CardState[], entity: Entity): CardState[] {
   if (existingIds.has(entity.id)) return cards;
 
   const newCard: CardState = { instanceId: `${entity.id}-${Date.now()}`, entity, pinned: false };
-  const next = insertAfterPinned(cards, newCard);
+  const nextCards = insertAfterPinned(cards, newCard);
 
-  if (next.length > MAX_CARDS) {
-    let evictIdx = -1;
-    for (let i = next.length - 1; i >= 0; i--) {
-      if (!next[i].pinned) { evictIdx = i; break; }
-    }
-    if (evictIdx === -1) return cards;
-    next.splice(evictIdx, 1);
+  if (nextCards.length > MAX_CARDS) {
+    const evictionIndex = findRightmostUnpinnedIndex(nextCards);
+    if (evictionIndex === -1) return cards;
+    nextCards.splice(evictionIndex, 1);
   }
 
-  return next;
+  return nextCards;
 }
 
 export function pinCard(cards: CardState[], instanceId: string): CardState[] {
-  const result = extractCard(cards, instanceId);
-  if (!result) return cards;
-  const [card, rest] = result;
+  const extracted = extractCard(cards, instanceId);
+  if (!extracted) return cards;
+  const [card, rest] = extracted;
   return [{ ...card, pinned: true }, ...rest];
 }
 
 export function unpinCard(cards: CardState[], instanceId: string): CardState[] {
-  const result = extractCard(cards, instanceId);
-  if (!result) return cards;
-  const [card, rest] = result;
+  const extracted = extractCard(cards, instanceId);
+  if (!extracted) return cards;
+  const [card, rest] = extracted;
   return insertAfterPinned(rest, { ...card, pinned: false });
 }
 
 export function dismissCard(cards: CardState[], instanceId: string): CardState[] {
-  return cards.filter((c) => c.instanceId !== instanceId);
+  return cards.filter((card) => card.instanceId !== instanceId);
 }

--- a/src/context/card-stack.ts
+++ b/src/context/card-stack.ts
@@ -1,0 +1,58 @@
+import type { Entity } from '../entities';
+import type { CardState } from './session-types';
+
+export const MAX_CARDS = 6;
+
+export function extractCard(cards: CardState[], instanceId: string): [CardState, CardState[]] | null {
+  const card = cards.find((c) => c.instanceId === instanceId);
+  if (!card) return null;
+  return [card, cards.filter((c) => c.instanceId !== instanceId)];
+}
+
+export function buildCardIdSet(cards: CardState[]): Set<string> {
+  return new Set(cards.map((c) => c.entity.id));
+}
+
+export function insertAfterPinned(cards: CardState[], card: CardState): CardState[] {
+  const lastPinnedIdx = cards.reduce((acc, c, i) => (c.pinned ? i : acc), -1);
+  const result = [...cards];
+  result.splice(lastPinnedIdx + 1, 0, card);
+  return result;
+}
+
+export function addCard(cards: CardState[], entity: Entity): CardState[] {
+  const existingIds = buildCardIdSet(cards);
+  if (existingIds.has(entity.id)) return cards;
+
+  const newCard: CardState = { instanceId: `${entity.id}-${Date.now()}`, entity, pinned: false };
+  const next = insertAfterPinned(cards, newCard);
+
+  if (next.length > MAX_CARDS) {
+    let evictIdx = -1;
+    for (let i = next.length - 1; i >= 0; i--) {
+      if (!next[i].pinned) { evictIdx = i; break; }
+    }
+    if (evictIdx === -1) return cards;
+    next.splice(evictIdx, 1);
+  }
+
+  return next;
+}
+
+export function pinCard(cards: CardState[], instanceId: string): CardState[] {
+  const result = extractCard(cards, instanceId);
+  if (!result) return cards;
+  const [card, rest] = result;
+  return [{ ...card, pinned: true }, ...rest];
+}
+
+export function unpinCard(cards: CardState[], instanceId: string): CardState[] {
+  const result = extractCard(cards, instanceId);
+  if (!result) return cards;
+  const [card, rest] = result;
+  return insertAfterPinned(rest, { ...card, pinned: false });
+}
+
+export function dismissCard(cards: CardState[], instanceId: string): CardState[] {
+  return cards.filter((c) => c.instanceId !== instanceId);
+}

--- a/src/context/data-sources.tsx
+++ b/src/context/data-sources.tsx
@@ -1,39 +1,15 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 import {
-  allowAppDataCacheWrites,
-  createAppDataWriteToken,
-  getAppDataItem,
-  isAppDataWriteTokenCurrent,
-  setAppDataItem,
+  createDefaultDataSourceSettings,
+  loadDataSourceSettings,
+  mergeDataSourceSettings,
+  saveDataSourceSettings,
 } from '../storage/app-data';
-import { DATA_SOURCES_KEY } from '../storage/keys';
+import type { DataSourcesSettings } from '../storage/app-data';
 
 export { DATA_SOURCES_KEY } from '../storage/keys';
-
-export interface DataSourcesSettings {
-  srdEnabled: boolean;
-  srdSources: string[];
-  kankaToken: string;
-  kankaCampaignId: string;
-  homebreweryUrl: string;
-  notionToken: string;
-  notionPageIds: string;
-  googleDocsUrl: string;
-  aiApiKey: string;
-}
-
-export const DEFAULT_DATA_SOURCES_SETTINGS: DataSourcesSettings = {
-  srdEnabled: true,
-  srdSources: ['wotc-srd'],
-  kankaToken: '',
-  kankaCampaignId: '',
-  homebreweryUrl: '',
-  notionToken: '',
-  notionPageIds: '',
-  googleDocsUrl: '',
-  aiApiKey: '',
-};
+export { DEFAULT_DATA_SOURCES_SETTINGS, type DataSourcesSettings } from '../storage/app-data';
 
 interface DataSourcesContextType {
   settings: DataSourcesSettings;
@@ -46,37 +22,24 @@ interface DataSourcesContextType {
 const DataSourcesContext = createContext<DataSourcesContextType | null>(null);
 
 export function DataSourcesProvider({ children }: { children: React.ReactNode }) {
-  const [settings, setSettings] = useState<DataSourcesSettings>(DEFAULT_DATA_SOURCES_SETTINGS);
+  const [settings, setSettings] = useState<DataSourcesSettings>(() => createDefaultDataSourceSettings());
   const [uploadsVersion, setUploadsVersion] = useState(0);
 
   useEffect(() => {
-    const token = createAppDataWriteToken();
-    getAppDataItem(DATA_SOURCES_KEY, token)
-      .then((raw) => {
-        if (raw) {
-          try {
-            setSettings({ ...DEFAULT_DATA_SOURCES_SETTINGS, ...(JSON.parse(raw) as Partial<DataSourcesSettings>) });
-          } catch (parseErr) {
-            console.warn('[dnd-ref] Failed to parse data source settings:', parseErr);
-          }
-        }
-      })
-      .catch((e) => console.warn('[dnd-ref] Failed to load data source settings:', e));
+    let mounted = true;
+    loadDataSourceSettings().then((loaded) => {
+      if (mounted && loaded) setSettings(loaded);
+    });
+    return () => { mounted = false; };
   }, []);
 
   async function update(patch: Partial<DataSourcesSettings>) {
-    const token = createAppDataWriteToken();
-    if (!isAppDataWriteTokenCurrent(token)) return;
     let next!: DataSourcesSettings;
     setSettings((prev) => {
-      next = { ...prev, ...patch };
+      next = mergeDataSourceSettings({ ...prev, ...patch });
       return next;
     });
-    const saved = await setAppDataItem(DATA_SOURCES_KEY, JSON.stringify(next), { token }).catch((e) => {
-      console.warn('[dnd-ref] Failed to save data source settings:', e);
-      return false;
-    });
-    if (saved) allowAppDataCacheWrites();
+    await saveDataSourceSettings(next);
   }
 
   const bumpUploads = useCallback(() => {
@@ -84,7 +47,7 @@ export function DataSourcesProvider({ children }: { children: React.ReactNode })
   }, []);
 
   const reset = useCallback(() => {
-    setSettings(DEFAULT_DATA_SOURCES_SETTINGS);
+    setSettings(createDefaultDataSourceSettings());
     setUploadsVersion((v) => v + 1);
   }, []);
 

--- a/src/context/data-sources.tsx
+++ b/src/context/data-sources.tsx
@@ -1,15 +1,19 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 import {
   createDefaultDataSourceSettings,
   loadDataSourceSettings,
   mergeDataSourceSettings,
   saveDataSourceSettings,
+  type DataSourcesSettings,
 } from '../storage/app-data';
-import type { DataSourcesSettings } from '../storage/app-data';
 
 export { DATA_SOURCES_KEY } from '../storage/keys';
-export { DEFAULT_DATA_SOURCES_SETTINGS, type DataSourcesSettings } from '../storage/app-data';
+export {
+  DEFAULT_DATA_SOURCES_SETTINGS,
+  createDefaultDataSourceSettings,
+  type DataSourcesSettings,
+} from '../storage/app-data';
 
 interface DataSourcesContextType {
   settings: DataSourcesSettings;
@@ -23,33 +27,41 @@ const DataSourcesContext = createContext<DataSourcesContextType | null>(null);
 
 export function DataSourcesProvider({ children }: { children: React.ReactNode }) {
   const [settings, setSettings] = useState<DataSourcesSettings>(() => createDefaultDataSourceSettings());
+  const latestSettings = useRef(settings);
   const [uploadsVersion, setUploadsVersion] = useState(0);
+
+  const replaceSettings = useCallback((nextSettings: DataSourcesSettings) => {
+    latestSettings.current = nextSettings;
+    setSettings(nextSettings);
+  }, []);
 
   useEffect(() => {
     let mounted = true;
-    loadDataSourceSettings().then((loaded) => {
-      if (mounted && loaded) setSettings(loaded);
-    });
-    return () => { mounted = false; };
-  }, []);
 
-  async function update(patch: Partial<DataSourcesSettings>) {
-    let next!: DataSourcesSettings;
-    setSettings((prev) => {
-      next = mergeDataSourceSettings({ ...prev, ...patch });
-      return next;
+    loadDataSourceSettings().then((loadedSettings) => {
+      if (!mounted || !loadedSettings) return;
+      replaceSettings(loadedSettings);
     });
-    await saveDataSourceSettings(next);
-  }
+
+    return () => {
+      mounted = false;
+    };
+  }, [replaceSettings]);
+
+  const update = useCallback(async (patch: Partial<DataSourcesSettings>) => {
+    const nextSettings = mergeDataSourceSettings({ ...latestSettings.current, ...patch });
+    replaceSettings(nextSettings);
+    await saveDataSourceSettings(nextSettings);
+  }, [replaceSettings]);
 
   const bumpUploads = useCallback(() => {
     setUploadsVersion((v) => v + 1);
   }, []);
 
   const reset = useCallback(() => {
-    setSettings(createDefaultDataSourceSettings());
+    replaceSettings(createDefaultDataSourceSettings());
     setUploadsVersion((v) => v + 1);
-  }, []);
+  }, [replaceSettings]);
 
   return (
     <DataSourcesContext.Provider value={{ settings, uploadsVersion, update, bumpUploads, reset }}>

--- a/src/context/session-helpers.ts
+++ b/src/context/session-helpers.ts
@@ -1,61 +1,14 @@
-import { Entity } from '../entities';
-import { CardState } from './session-types';
-
-export const MAX_CARDS = 6;
 export const DETECT_INTERVAL_MS = 2000;
 
-export function extractCard(cards: CardState[], instanceId: string): [CardState, CardState[]] | null {
-  const card = cards.find((c) => c.instanceId === instanceId);
-  if (!card) return null;
-  return [card, cards.filter((c) => c.instanceId !== instanceId)];
-}
-
-export function buildCardIdSet(cards: CardState[]): Set<string> {
-  return new Set(cards.map((c) => c.entity.id));
-}
-
-export function insertAfterPinned(cards: CardState[], card: CardState): CardState[] {
-  const lastPinnedIdx = cards.reduce((acc, c, i) => (c.pinned ? i : acc), -1);
-  const result = [...cards];
-  result.splice(lastPinnedIdx + 1, 0, card);
-  return result;
-}
-
-export function addCard(cards: CardState[], entity: Entity): CardState[] {
-  const existingIds = buildCardIdSet(cards);
-  if (existingIds.has(entity.id)) return cards;
-
-  const newCard: CardState = { instanceId: `${entity.id}-${Date.now()}`, entity, pinned: false };
-  const next = insertAfterPinned(cards, newCard);
-
-  if (next.length > MAX_CARDS) {
-    let evictIdx = -1;
-    for (let i = next.length - 1; i >= 0; i--) {
-      if (!next[i].pinned) { evictIdx = i; break; }
-    }
-    if (evictIdx === -1) return cards;
-    next.splice(evictIdx, 1);
-  }
-
-  return next;
-}
-
-export function pinCard(cards: CardState[], instanceId: string): CardState[] {
-  const result = extractCard(cards, instanceId);
-  if (!result) return cards;
-  const [card, rest] = result;
-  return [{ ...card, pinned: true }, ...rest];
-}
-
-export function unpinCard(cards: CardState[], instanceId: string): CardState[] {
-  const result = extractCard(cards, instanceId);
-  if (!result) return cards;
-  const [card, rest] = result;
-  return insertAfterPinned(rest, { ...card, pinned: false });
-}
-
-export function dismissCard(cards: CardState[], instanceId: string): CardState[] {
-  return cards.filter((c) => c.instanceId !== instanceId);
-}
+export {
+  MAX_CARDS,
+  extractCard,
+  buildCardIdSet,
+  insertAfterPinned,
+  addCard,
+  pinCard,
+  unpinCard,
+  dismissCard,
+} from './card-stack';
 
 export { loadSettings, buildProvider } from '../stt/build-provider';

--- a/src/context/session-runtime.test.ts
+++ b/src/context/session-runtime.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Entity } from '../entities';
+import { SessionRuntime, type SessionRuntimeDetector } from './session-runtime';
+
+function makeEntity(id: string, name: string): Entity {
+  return {
+    id,
+    name,
+    type: 'NPC',
+    aliases: [],
+    summary: `${name} summary`,
+  };
+}
+
+class FakeDetector implements SessionRuntimeDetector {
+  inputs: string[] = [];
+
+  constructor(private readonly respond: (input: string) => Entity[]) {}
+
+  detect(input: string): Entity[] {
+    this.inputs.push(input);
+    return this.respond(input);
+  }
+}
+
+function normalizeSpaces(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+describe('SessionRuntime', () => {
+  it('carries active transcript context so split entity names are detected', () => {
+    const redOakKeep = makeEntity('red-oak-keep', 'Red Oak Keep');
+    const detector = new FakeDetector((input) => (
+      normalizeSpaces(input).includes('Red Oak Keep') ? [redOakKeep] : []
+    ));
+    const runtime = new SessionRuntime();
+
+    runtime.setDetector(detector);
+    runtime.activate();
+    runtime.appendTranscript('The party reached Red');
+    runtime.processTranscript();
+    runtime.appendTranscript('Oak Keep before sunset');
+    runtime.processTranscript();
+
+    const lastInput = detector.inputs[detector.inputs.length - 1];
+    expect(normalizeSpaces(lastInput)).toContain('Red Oak Keep before sunset');
+    expect(runtime.getSnapshot().cards.map((card) => card.entity.name)).toEqual(['Red Oak Keep']);
+    expect(runtime.getSnapshot().recentDetections).toEqual([redOakKeep]);
+  });
+
+  it('suppresses duplicate detections without replacing recent detections or cards', () => {
+    const valdrath = makeEntity('valdrath', 'Valdrath the Undying');
+    const detector = new FakeDetector((input) => (
+      input.includes('Valdrath') ? [valdrath] : []
+    ));
+    const runtime = new SessionRuntime();
+
+    runtime.setDetector(detector);
+    runtime.activate();
+    runtime.appendTranscript('Valdrath spoke first');
+    runtime.processTranscript();
+    const firstCards = runtime.getSnapshot().cards;
+    const firstRecentDetections = runtime.getSnapshot().recentDetections;
+
+    runtime.appendTranscript('then Valdrath spoke again');
+    runtime.processTranscript();
+
+    expect(runtime.getSnapshot().cards).toBe(firstCards);
+    expect(runtime.getSnapshot().cards).toHaveLength(1);
+    expect(runtime.getSnapshot().recentDetections).toBe(firstRecentDetections);
+  });
+
+  it('adds detected entities to the card stack and recent detections', () => {
+    const valdrath = makeEntity('valdrath', 'Valdrath the Undying');
+    const malachar = makeEntity('malachar', 'Malachar the Grey');
+    const detector = new FakeDetector(() => [valdrath, malachar]);
+    const runtime = new SessionRuntime();
+
+    runtime.setDetector(detector);
+    runtime.activate();
+    runtime.appendTranscript('Valdrath summoned Malachar to the fortress');
+    runtime.processTranscript();
+
+    expect(runtime.getSnapshot().cards.map((card) => card.entity.id).sort()).toEqual(['malachar', 'valdrath']);
+    expect(runtime.getSnapshot().cards).toHaveLength(2);
+    expect(runtime.getSnapshot().cards.every((card) => !card.pinned)).toBe(true);
+    expect(runtime.getSnapshot().recentDetections).toEqual([valdrath, malachar]);
+  });
+});

--- a/src/context/session-runtime.test.ts
+++ b/src/context/session-runtime.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { Entity } from '../entities';
+import type { STTProvider, STTSettings } from '../stt';
 import { SessionRuntime, type SessionRuntimeDetector } from './session-runtime';
+
+const TEST_STT_SETTINGS: STTSettings = { provider: 'web-speech', deepgramApiKey: '' };
 
 function makeEntity(id: string, name: string): Entity {
   return {
@@ -22,6 +25,62 @@ class FakeDetector implements SessionRuntimeDetector {
     this.inputs.push(input);
     return this.respond(input);
   }
+}
+
+class FakeSTTProvider implements STTProvider {
+  readonly name = 'Fake STT';
+  pauseCalls = 0;
+  resumeCalls = 0;
+  startCalls = 0;
+  stopCalls = 0;
+  resumeError: unknown = null;
+  startError: unknown = null;
+
+  constructor(
+    private readonly onTranscript: (text: string) => void,
+    private readonly onError: (error: string) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    this.startCalls += 1;
+    if (this.startError) throw this.startError;
+  }
+
+  async pause(): Promise<void> {
+    this.pauseCalls += 1;
+  }
+
+  async resume(): Promise<void> {
+    this.resumeCalls += 1;
+    if (this.resumeError) throw this.resumeError;
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+  }
+
+  emitTranscript(text: string): void {
+    this.onTranscript(text);
+  }
+
+  emitError(error: string): void {
+    this.onError(error);
+  }
+}
+
+function makeRuntimeWithFakeStt(configure?: (provider: FakeSTTProvider) => void) {
+  const providers: FakeSTTProvider[] = [];
+  const runtime = new SessionRuntime({
+    loadSttSettings: async () => TEST_STT_SETTINGS,
+    buildSttProvider: (_settings, onTranscript, onError) => {
+      const provider = new FakeSTTProvider(onTranscript, onError);
+      configure?.(provider);
+      providers.push(provider);
+      return provider;
+    },
+    detectIntervalMs: 0,
+  });
+  return { providers, runtime };
 }
 
 function normalizeSpaces(value: string): string {
@@ -86,5 +145,149 @@ describe('SessionRuntime', () => {
     expect(runtime.getSnapshot().cards).toHaveLength(2);
     expect(runtime.getSnapshot().cards.every((card) => !card.pinned)).toBe(true);
     expect(runtime.getSnapshot().recentDetections).toEqual([valdrath, malachar]);
+  });
+
+  it('runs detection from its own active interval and clears the interval when paused', () => {
+    vi.useFakeTimers();
+    let runtime: SessionRuntime | null = null;
+    try {
+      const valdrath = makeEntity('valdrath', 'Valdrath the Undying');
+      const seraphine = makeEntity('seraphine', 'Lady Seraphine Voss');
+      const detector = new FakeDetector((input) => [
+        ...(input.includes('Valdrath') ? [valdrath] : []),
+        ...(input.includes('Seraphine') ? [seraphine] : []),
+      ]);
+      runtime = new SessionRuntime({ detectIntervalMs: 100 });
+      runtime.setDetector(detector);
+
+      runtime.activate();
+      runtime.appendTranscript('Valdrath watches from the throne');
+      vi.advanceTimersByTime(100);
+      expect(runtime.getSnapshot().cards.map((card) => card.entity.id)).toEqual(['valdrath']);
+
+      runtime.pause();
+      runtime.appendTranscript('Seraphine entered while paused');
+      vi.advanceTimersByTime(300);
+      expect(runtime.getSnapshot().cards.map((card) => card.entity.id)).toEqual(['valdrath']);
+    } finally {
+      runtime?.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('starts, pauses, resumes, gates speech, and stops through the runtime', async () => {
+    const valdrath = makeEntity('valdrath', 'Valdrath the Undying');
+    const detector = new FakeDetector((input) => (input.includes('Valdrath') ? [valdrath] : []));
+    const { providers, runtime } = makeRuntimeWithFakeStt();
+    runtime.setDetector(detector);
+
+    await runtime.start();
+    const provider = providers[0];
+    expect(runtime.getSnapshot()).toMatchObject({
+      status: 'active',
+      sttStatus: 'active',
+      sttError: null,
+      sttProviderName: 'Fake STT',
+    });
+
+    provider.emitTranscript('Valdrath spoke first');
+    runtime.processTranscript();
+    expect(runtime.getSnapshot().cards.map((card) => card.entity.id)).toEqual(['valdrath']);
+
+    runtime.pause();
+    expect(provider.pauseCalls).toBe(1);
+    provider.emitTranscript('Malachar was only heard while paused');
+    expect(runtime.getSnapshot().transcript).toBe('Valdrath spoke first');
+
+    await runtime.resume();
+    expect(providers).toHaveLength(1);
+    expect(provider.resumeCalls).toBe(1);
+    provider.emitTranscript('Seraphine spoke after resume');
+    expect(runtime.getSnapshot().transcript).toBe('Valdrath spoke first Seraphine spoke after resume');
+
+    runtime.stop();
+    expect(provider.stopCalls).toBe(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      status: 'idle',
+      sttStatus: 'idle',
+      sttError: null,
+      sttProviderName: '',
+      cards: [],
+      recentDetections: [],
+      transcript: '',
+    });
+    provider.emitTranscript('late speech');
+    provider.emitError('late error');
+    expect(runtime.getSnapshot()).toMatchObject({ sttError: null, transcript: '' });
+  });
+
+  it('reports start failures, clears provider state, and can retry', async () => {
+    let failNextStart = true;
+    const { providers, runtime } = makeRuntimeWithFakeStt((provider) => {
+      if (failNextStart) {
+        provider.startError = new Error('permission denied');
+        failNextStart = false;
+      }
+    });
+
+    await runtime.start();
+    expect(providers[0].startCalls).toBe(1);
+    expect(providers[0].stopCalls).toBe(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      status: 'idle',
+      sttStatus: 'error',
+      sttError: 'Failed to start mic: permission denied',
+      sttProviderName: '',
+    });
+
+    await runtime.start();
+    expect(providers).toHaveLength(2);
+    expect(providers[1].startCalls).toBe(1);
+    expect(runtime.getSnapshot()).toMatchObject({ status: 'active', sttStatus: 'active', sttError: null });
+  });
+
+  it('reports resume failures, ignores stale speech, and creates a fresh provider on retry', async () => {
+    const { providers, runtime } = makeRuntimeWithFakeStt();
+    await runtime.start();
+    const provider = providers[0];
+    runtime.pause();
+    provider.resumeError = new Error('device lost');
+
+    await runtime.resume();
+    expect(provider.resumeCalls).toBe(1);
+    expect(provider.stopCalls).toBe(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      status: 'paused',
+      sttStatus: 'error',
+      sttError: 'Failed to resume mic: device lost',
+    });
+
+    provider.emitTranscript('stale speech after resume failure');
+    expect(runtime.getSnapshot().transcript).toBe('');
+
+    await runtime.start();
+    expect(providers).toHaveLength(2);
+    expect(runtime.getSnapshot()).toMatchObject({ status: 'active', sttStatus: 'active', sttError: null });
+  });
+
+  it('handles provider error callbacks by pausing and allowing a fresh start', async () => {
+    const { providers, runtime } = makeRuntimeWithFakeStt();
+    await runtime.start();
+    const provider = providers[0];
+
+    provider.emitError('Mic error: audio-capture');
+
+    expect(provider.stopCalls).toBe(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      status: 'paused',
+      sttStatus: 'error',
+      sttError: 'Mic error: audio-capture',
+    });
+    provider.emitTranscript('speech after fatal error');
+    expect(runtime.getSnapshot().transcript).toBe('');
+
+    await runtime.start();
+    expect(providers).toHaveLength(2);
+    expect(runtime.getSnapshot()).toMatchObject({ status: 'active', sttStatus: 'active', sttError: null });
   });
 });

--- a/src/context/session-runtime.test.ts
+++ b/src/context/session-runtime.test.ts
@@ -68,7 +68,9 @@ class FakeSTTProvider implements STTProvider {
   }
 }
 
-function makeRuntimeWithFakeStt(configure?: (provider: FakeSTTProvider) => void) {
+function makeRuntimeWithFakeStt(
+  configure?: (provider: FakeSTTProvider) => void,
+): { providers: FakeSTTProvider[]; runtime: SessionRuntime } {
   const providers: FakeSTTProvider[] = [];
   const runtime = new SessionRuntime({
     loadSttSettings: async () => TEST_STT_SETTINGS,

--- a/src/context/session-runtime.ts
+++ b/src/context/session-runtime.ts
@@ -1,0 +1,132 @@
+import type { Entity } from '../entities';
+import { addCard, dismissCard, pinCard, unpinCard } from './card-stack';
+import { buildDetectionInput, nextDetectionContext } from './detection-window';
+import type { CardState, SessionStatus } from './session-types';
+
+export interface SessionRuntimeDetector {
+  detect(transcript: string): Entity[];
+}
+
+export interface SessionRuntimeSnapshot {
+  status: SessionStatus;
+  cards: CardState[];
+  transcript: string;
+  recentDetections: Entity[];
+}
+
+type SessionRuntimeListener = (snapshot: SessionRuntimeSnapshot) => void;
+
+export class SessionRuntime {
+  private detector: SessionRuntimeDetector | null = null;
+  private detectionContext = '';
+  private listeners = new Set<SessionRuntimeListener>();
+  private prevDetectionKey = '';
+  private processedUpTo = 0;
+  private snapshot: SessionRuntimeSnapshot = {
+    status: 'idle',
+    cards: [],
+    transcript: '',
+    recentDetections: [],
+  };
+
+  getSnapshot(): SessionRuntimeSnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(listener: SessionRuntimeListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  setDetector(detector: SessionRuntimeDetector | null): void {
+    this.detector = detector;
+  }
+
+  activate(): void {
+    this.processedUpTo = this.snapshot.transcript.length;
+    this.detectionContext = '';
+    this.replaceSnapshot({ status: 'active' });
+  }
+
+  pause(): void {
+    this.detectionContext = '';
+    this.replaceSnapshot({ status: 'paused' });
+  }
+
+  stop(): void {
+    this.processedUpTo = 0;
+    this.detectionContext = '';
+    this.prevDetectionKey = '';
+    this.replaceSnapshot({
+      status: 'idle',
+      cards: [],
+      transcript: '',
+      recentDetections: [],
+    });
+  }
+
+  appendTranscript(text: string): void {
+    const transcript = this.snapshot.transcript ? `${this.snapshot.transcript} ${text}` : text;
+    this.replaceSnapshot({ transcript });
+  }
+
+  processTranscript(): void {
+    if (this.snapshot.status !== 'active') return;
+    if (!this.detector) return;
+
+    const newText = this.snapshot.transcript.slice(this.processedUpTo);
+    if (!newText.trim()) return;
+
+    const found = this.detector.detect(buildDetectionInput(this.detectionContext, newText));
+    this.processedUpTo = this.snapshot.transcript.length;
+    this.detectionContext = nextDetectionContext(this.snapshot.transcript);
+
+    if (found.length === 0) return;
+
+    let cards = this.snapshot.cards;
+    for (const entity of found) {
+      cards = addCard(cards, entity);
+    }
+
+    const detectionKey = found.map((entity) => entity.id).join(',');
+    const shouldUpdateRecentDetections = detectionKey !== this.prevDetectionKey;
+    if (shouldUpdateRecentDetections) {
+      this.prevDetectionKey = detectionKey;
+    }
+
+    this.replaceSnapshot({
+      ...(cards !== this.snapshot.cards ? { cards } : {}),
+      ...(shouldUpdateRecentDetections ? { recentDetections: found } : {}),
+    });
+  }
+
+  pin(instanceId: string): void {
+    const cards = pinCard(this.snapshot.cards, instanceId);
+    if (cards !== this.snapshot.cards) this.replaceSnapshot({ cards });
+  }
+
+  unpin(instanceId: string): void {
+    const cards = unpinCard(this.snapshot.cards, instanceId);
+    if (cards !== this.snapshot.cards) this.replaceSnapshot({ cards });
+  }
+
+  dismiss(instanceId: string): void {
+    const cards = dismissCard(this.snapshot.cards, instanceId);
+    if (cards !== this.snapshot.cards) this.replaceSnapshot({ cards });
+  }
+
+  private replaceSnapshot(patch: Partial<SessionRuntimeSnapshot>): void {
+    if (Object.keys(patch).length === 0) return;
+    this.snapshot = { ...this.snapshot, ...patch };
+    this.emit();
+  }
+
+  private emit(): void {
+    const snapshot = this.snapshot;
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+}

--- a/src/context/session-runtime.ts
+++ b/src/context/session-runtime.ts
@@ -1,7 +1,8 @@
 import type { Entity } from '../entities';
+import type { STTProvider, STTSettings } from '../stt';
 import { addCard, dismissCard, pinCard, unpinCard } from './card-stack';
 import { buildDetectionInput, nextDetectionContext } from './detection-window';
-import type { CardState, SessionStatus } from './session-types';
+import type { CardState, SessionStatus, SttStatus } from './session-types';
 
 export interface SessionRuntimeDetector {
   detect(transcript: string): Entity[];
@@ -9,62 +10,94 @@ export interface SessionRuntimeDetector {
 
 export interface SessionRuntimeSnapshot {
   status: SessionStatus;
+  sttStatus: SttStatus;
+  sttError: string | null;
+  sttProviderName: string;
   cards: CardState[];
   transcript: string;
   recentDetections: Entity[];
 }
 
+export interface SessionRuntimeOptions {
+  loadSttSettings?: () => Promise<STTSettings>;
+  buildSttProvider?: (settings: STTSettings, onTranscript: (text: string) => void, onError: (error: string) => void) => STTProvider;
+  detectIntervalMs?: number;
+}
+
 type SessionRuntimeListener = (snapshot: SessionRuntimeSnapshot) => void;
+type DetectionInterval = ReturnType<typeof setInterval>;
 
 export class SessionRuntime {
+  private acceptingTranscript = false;
   private detector: SessionRuntimeDetector | null = null;
-  private listeners = new Set<SessionRuntimeListener>();
+  private detectionInterval: DetectionInterval | null = null;
+  private readonly detectIntervalMs: number;
+  private readonly buildSttProvider?: SessionRuntimeOptions['buildSttProvider'];
+  private readonly loadSttSettings?: SessionRuntimeOptions['loadSttSettings'];
   private lastDetectionKey = '';
+  private listeners = new Set<SessionRuntimeListener>();
   private previousDetectionContext = '';
   private processedTranscriptLength = 0;
+  private startInFlight: Promise<void> | null = null;
+  private sttGeneration = 0;
+  private sttProvider: STTProvider | null = null;
   private snapshot: SessionRuntimeSnapshot = {
     status: 'idle',
+    sttStatus: 'idle',
+    sttError: null,
+    sttProviderName: '',
     cards: [],
     transcript: '',
     recentDetections: [],
   };
 
-  getSnapshot(): SessionRuntimeSnapshot {
-    return this.snapshot;
+  constructor(options: SessionRuntimeOptions = {}) {
+    this.loadSttSettings = options.loadSttSettings;
+    this.buildSttProvider = options.buildSttProvider;
+    this.detectIntervalMs = options.detectIntervalMs ?? 0;
   }
+
+  getSnapshot(): SessionRuntimeSnapshot { return this.snapshot; }
 
   subscribe(listener: SessionRuntimeListener): () => void {
     this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
+    return () => { this.listeners.delete(listener); };
   }
 
-  setDetector(detector: SessionRuntimeDetector | null): void {
-    this.detector = detector;
+  setDetector(detector: SessionRuntimeDetector | null): void { this.detector = detector; }
+
+  start(): Promise<void> {
+    if (this.startInFlight) return this.startInFlight;
+    const command = this.sttProvider
+      ? this.resumeExistingProvider(this.sttProvider, this.sttGeneration)
+      : this.startNewProvider();
+    this.startInFlight = command;
+    const clearInFlight = () => { if (this.startInFlight === command) this.startInFlight = null; };
+    command.then(clearInFlight, clearInFlight);
+    return command;
   }
 
-  activate(): void {
-    this.processedTranscriptLength = this.snapshot.transcript.length;
-    this.previousDetectionContext = '';
-    this.updateSnapshot({ status: 'active' });
-  }
+  resume(): Promise<void> { return this.start(); }
+  activate(): void { this.activateSession(); }
 
   pause(): void {
-    this.previousDetectionContext = '';
-    this.updateSnapshot({ status: 'paused' });
+    this.acceptingTranscript = false;
+    const provider = this.sttProvider;
+    if (provider) void Promise.resolve(provider.pause()).catch(() => {});
+    this.pauseSession({ sttStatus: 'idle' });
   }
 
   stop(): void {
-    this.processedTranscriptLength = 0;
-    this.previousDetectionContext = '';
-    this.lastDetectionKey = '';
-    this.updateSnapshot({
-      status: 'idle',
-      cards: [],
-      transcript: '',
-      recentDetections: [],
-    });
+    const provider = this.invalidateStt();
+    if (provider) void this.stopProvider(provider);
+    this.stopSession({ sttStatus: 'idle', sttError: null, sttProviderName: '' });
+  }
+
+  dispose(): void {
+    const provider = this.invalidateStt();
+    this.clearDetectionInterval();
+    if (provider) void this.stopProvider(provider);
+    this.listeners.clear();
   }
 
   appendTranscript(text: string): void {
@@ -75,7 +108,6 @@ export class SessionRuntime {
   processTranscript(): void {
     if (this.snapshot.status !== 'active') return;
     if (!this.detector) return;
-
     const newText = this.snapshot.transcript.slice(this.processedTranscriptLength);
     if (!newText.trim()) return;
 
@@ -83,23 +115,16 @@ export class SessionRuntime {
     const detectedEntities = this.detector.detect(detectionInput);
     this.processedTranscriptLength = this.snapshot.transcript.length;
     this.previousDetectionContext = nextDetectionContext(this.snapshot.transcript);
-
     if (detectedEntities.length === 0) return;
 
     let nextCards = this.snapshot.cards;
-    for (const entity of detectedEntities) {
-      nextCards = addCard(nextCards, entity);
-    }
-
+    for (const entity of detectedEntities) nextCards = addCard(nextCards, entity);
     const detectionKey = detectedEntities.map((entity) => entity.id).join(',');
     const recentDetectionsChanged = detectionKey !== this.lastDetectionKey;
-    if (recentDetectionsChanged) {
-      this.lastDetectionKey = detectionKey;
-    }
+    if (recentDetectionsChanged) this.lastDetectionKey = detectionKey;
 
     const cardsChanged = nextCards !== this.snapshot.cards;
     if (!cardsChanged && !recentDetectionsChanged) return;
-
     const snapshotPatch: Partial<SessionRuntimeSnapshot> = {};
     if (cardsChanged) snapshotPatch.cards = nextCards;
     if (recentDetectionsChanged) snapshotPatch.recentDetections = detectedEntities;
@@ -121,6 +146,127 @@ export class SessionRuntime {
     if (cards !== this.snapshot.cards) this.updateSnapshot({ cards });
   }
 
+  private async startNewProvider(): Promise<void> {
+    const generation = this.sttGeneration + 1;
+    this.sttGeneration = generation;
+    this.acceptingTranscript = false;
+    this.updateSnapshot({ sttStatus: 'connecting', sttError: null });
+
+    try {
+      if (!this.loadSttSettings || !this.buildSttProvider) throw new Error('STT provider factory not configured.');
+      const settings = await this.loadSttSettings();
+      if (this.sttGeneration !== generation) return;
+      const provider = this.buildSttProvider(
+        settings,
+        (text) => this.acceptProviderTranscript(text, generation),
+        (error) => this.handleProviderError(error, generation),
+      );
+      this.sttProvider = provider;
+      this.updateSnapshot({ sttProviderName: provider.name });
+
+      await provider.start();
+      if (this.sttGeneration !== generation || this.sttProvider !== provider) {
+        await this.stopProvider(provider);
+        return;
+      }
+      this.acceptingTranscript = true;
+      this.activateSession({ sttStatus: 'active', sttError: null });
+    } catch (e) {
+      if (this.sttGeneration !== generation) return;
+      const provider = this.sttProvider;
+      if (provider) void this.stopProvider(provider);
+      this.sttProvider = null;
+      this.acceptingTranscript = false;
+      this.updateSnapshot({
+        sttProviderName: '',
+        sttError: `Failed to start mic: ${this.formatError(e)}`,
+        sttStatus: 'error',
+      });
+    }
+  }
+
+  private async resumeExistingProvider(provider: STTProvider, generation: number): Promise<void> {
+    try {
+      await Promise.resolve(provider.resume());
+      if (this.sttGeneration !== generation || this.sttProvider !== provider) return;
+      this.acceptingTranscript = true;
+      this.activateSession({ sttStatus: 'active', sttError: null });
+    } catch (e) {
+      if (this.sttGeneration !== generation || this.sttProvider !== provider) return;
+      this.acceptingTranscript = false;
+      await this.stopProvider(provider);
+      if (this.sttProvider === provider) this.sttProvider = null;
+      this.pauseSession({
+        sttError: `Failed to resume mic: ${this.formatError(e)}`,
+        sttStatus: 'error',
+      });
+    }
+  }
+
+  private acceptProviderTranscript(text: string, generation: number): void {
+    if (this.sttGeneration === generation && this.acceptingTranscript) this.appendTranscript(text);
+  }
+
+  private handleProviderError(error: string, generation: number): void {
+    if (this.sttGeneration !== generation) return;
+    this.acceptingTranscript = false;
+    const provider = this.sttProvider;
+    if (provider) void this.stopProvider(provider);
+    this.sttProvider = null;
+    const patch = { sttError: error, sttStatus: 'error' as SttStatus };
+    if (this.snapshot.status === 'active') this.pauseSession(patch);
+    else this.updateSnapshot(patch);
+  }
+
+  private activateSession(patch: Partial<SessionRuntimeSnapshot> = {}): void {
+    this.processedTranscriptLength = this.snapshot.transcript.length;
+    this.previousDetectionContext = '';
+    this.startDetectionInterval();
+    this.updateSnapshot({ status: 'active', ...patch });
+  }
+
+  private pauseSession(patch: Partial<SessionRuntimeSnapshot> = {}): void {
+    this.previousDetectionContext = '';
+    this.clearDetectionInterval();
+    this.updateSnapshot({ status: 'paused', ...patch });
+  }
+
+  private stopSession(patch: Partial<SessionRuntimeSnapshot> = {}): void {
+    this.processedTranscriptLength = 0;
+    this.previousDetectionContext = '';
+    this.lastDetectionKey = '';
+    this.clearDetectionInterval();
+    this.updateSnapshot({ status: 'idle', cards: [], transcript: '', recentDetections: [], ...patch });
+  }
+
+  private startDetectionInterval(): void {
+    this.clearDetectionInterval();
+    if (this.detectIntervalMs <= 0) return;
+    this.detectionInterval = setInterval(() => this.processTranscript(), this.detectIntervalMs);
+    (this.detectionInterval as { unref?: () => void }).unref?.();
+  }
+
+  private clearDetectionInterval(): void {
+    if (!this.detectionInterval) return;
+    clearInterval(this.detectionInterval);
+    this.detectionInterval = null;
+  }
+
+  private invalidateStt(): STTProvider | null {
+    this.sttGeneration += 1;
+    this.startInFlight = null;
+    this.acceptingTranscript = false;
+    const provider = this.sttProvider;
+    this.sttProvider = null;
+    return provider;
+  }
+
+  private async stopProvider(provider: STTProvider): Promise<void> {
+    try { await Promise.resolve(provider.stop()); } catch {}
+  }
+
+  private formatError(error: unknown): string { return error instanceof Error ? error.message : String(error); }
+
   private updateSnapshot(patch: Partial<SessionRuntimeSnapshot>): void {
     if (Object.keys(patch).length === 0) return;
     this.snapshot = { ...this.snapshot, ...patch };
@@ -129,8 +275,6 @@ export class SessionRuntime {
 
   private notifyListeners(): void {
     const snapshot = this.snapshot;
-    for (const listener of this.listeners) {
-      listener(snapshot);
-    }
+    for (const listener of this.listeners) listener(snapshot);
   }
 }

--- a/src/context/session-runtime.ts
+++ b/src/context/session-runtime.ts
@@ -18,10 +18,10 @@ type SessionRuntimeListener = (snapshot: SessionRuntimeSnapshot) => void;
 
 export class SessionRuntime {
   private detector: SessionRuntimeDetector | null = null;
-  private detectionContext = '';
   private listeners = new Set<SessionRuntimeListener>();
-  private prevDetectionKey = '';
-  private processedUpTo = 0;
+  private lastDetectionKey = '';
+  private previousDetectionContext = '';
+  private processedTranscriptLength = 0;
   private snapshot: SessionRuntimeSnapshot = {
     status: 'idle',
     cards: [],
@@ -45,21 +45,21 @@ export class SessionRuntime {
   }
 
   activate(): void {
-    this.processedUpTo = this.snapshot.transcript.length;
-    this.detectionContext = '';
-    this.replaceSnapshot({ status: 'active' });
+    this.processedTranscriptLength = this.snapshot.transcript.length;
+    this.previousDetectionContext = '';
+    this.updateSnapshot({ status: 'active' });
   }
 
   pause(): void {
-    this.detectionContext = '';
-    this.replaceSnapshot({ status: 'paused' });
+    this.previousDetectionContext = '';
+    this.updateSnapshot({ status: 'paused' });
   }
 
   stop(): void {
-    this.processedUpTo = 0;
-    this.detectionContext = '';
-    this.prevDetectionKey = '';
-    this.replaceSnapshot({
+    this.processedTranscriptLength = 0;
+    this.previousDetectionContext = '';
+    this.lastDetectionKey = '';
+    this.updateSnapshot({
       status: 'idle',
       cards: [],
       transcript: '',
@@ -69,61 +69,65 @@ export class SessionRuntime {
 
   appendTranscript(text: string): void {
     const transcript = this.snapshot.transcript ? `${this.snapshot.transcript} ${text}` : text;
-    this.replaceSnapshot({ transcript });
+    this.updateSnapshot({ transcript });
   }
 
   processTranscript(): void {
     if (this.snapshot.status !== 'active') return;
     if (!this.detector) return;
 
-    const newText = this.snapshot.transcript.slice(this.processedUpTo);
+    const newText = this.snapshot.transcript.slice(this.processedTranscriptLength);
     if (!newText.trim()) return;
 
-    const found = this.detector.detect(buildDetectionInput(this.detectionContext, newText));
-    this.processedUpTo = this.snapshot.transcript.length;
-    this.detectionContext = nextDetectionContext(this.snapshot.transcript);
+    const detectionInput = buildDetectionInput(this.previousDetectionContext, newText);
+    const detectedEntities = this.detector.detect(detectionInput);
+    this.processedTranscriptLength = this.snapshot.transcript.length;
+    this.previousDetectionContext = nextDetectionContext(this.snapshot.transcript);
 
-    if (found.length === 0) return;
+    if (detectedEntities.length === 0) return;
 
-    let cards = this.snapshot.cards;
-    for (const entity of found) {
-      cards = addCard(cards, entity);
+    let nextCards = this.snapshot.cards;
+    for (const entity of detectedEntities) {
+      nextCards = addCard(nextCards, entity);
     }
 
-    const detectionKey = found.map((entity) => entity.id).join(',');
-    const shouldUpdateRecentDetections = detectionKey !== this.prevDetectionKey;
-    if (shouldUpdateRecentDetections) {
-      this.prevDetectionKey = detectionKey;
+    const detectionKey = detectedEntities.map((entity) => entity.id).join(',');
+    const recentDetectionsChanged = detectionKey !== this.lastDetectionKey;
+    if (recentDetectionsChanged) {
+      this.lastDetectionKey = detectionKey;
     }
 
-    this.replaceSnapshot({
-      ...(cards !== this.snapshot.cards ? { cards } : {}),
-      ...(shouldUpdateRecentDetections ? { recentDetections: found } : {}),
-    });
+    const cardsChanged = nextCards !== this.snapshot.cards;
+    if (!cardsChanged && !recentDetectionsChanged) return;
+
+    const snapshotPatch: Partial<SessionRuntimeSnapshot> = {};
+    if (cardsChanged) snapshotPatch.cards = nextCards;
+    if (recentDetectionsChanged) snapshotPatch.recentDetections = detectedEntities;
+    this.updateSnapshot(snapshotPatch);
   }
 
   pin(instanceId: string): void {
     const cards = pinCard(this.snapshot.cards, instanceId);
-    if (cards !== this.snapshot.cards) this.replaceSnapshot({ cards });
+    if (cards !== this.snapshot.cards) this.updateSnapshot({ cards });
   }
 
   unpin(instanceId: string): void {
     const cards = unpinCard(this.snapshot.cards, instanceId);
-    if (cards !== this.snapshot.cards) this.replaceSnapshot({ cards });
+    if (cards !== this.snapshot.cards) this.updateSnapshot({ cards });
   }
 
   dismiss(instanceId: string): void {
     const cards = dismissCard(this.snapshot.cards, instanceId);
-    if (cards !== this.snapshot.cards) this.replaceSnapshot({ cards });
+    if (cards !== this.snapshot.cards) this.updateSnapshot({ cards });
   }
 
-  private replaceSnapshot(patch: Partial<SessionRuntimeSnapshot>): void {
+  private updateSnapshot(patch: Partial<SessionRuntimeSnapshot>): void {
     if (Object.keys(patch).length === 0) return;
     this.snapshot = { ...this.snapshot, ...patch };
-    this.emit();
+    this.notifyListeners();
   }
 
-  private emit(): void {
+  private notifyListeners(): void {
     const snapshot = this.snapshot;
     for (const listener of this.listeners) {
       listener(snapshot);

--- a/src/context/session-runtime.ts
+++ b/src/context/session-runtime.ts
@@ -18,14 +18,22 @@ export interface SessionRuntimeSnapshot {
   recentDetections: Entity[];
 }
 
+type SttSettingsLoader = () => Promise<STTSettings>;
+type SttProviderBuilder = (
+  settings: STTSettings,
+  onTranscript: (text: string) => void,
+  onError: (error: string) => void,
+) => STTProvider;
+
 export interface SessionRuntimeOptions {
-  loadSttSettings?: () => Promise<STTSettings>;
-  buildSttProvider?: (settings: STTSettings, onTranscript: (text: string) => void, onError: (error: string) => void) => STTProvider;
+  loadSttSettings?: SttSettingsLoader;
+  buildSttProvider?: SttProviderBuilder;
   detectIntervalMs?: number;
 }
 
 type SessionRuntimeListener = (snapshot: SessionRuntimeSnapshot) => void;
 type DetectionInterval = ReturnType<typeof setInterval>;
+type SnapshotPatch = Partial<SessionRuntimeSnapshot>;
 
 export class SessionRuntime {
   private acceptingTranscript = false;
@@ -68,29 +76,33 @@ export class SessionRuntime {
 
   start(): Promise<void> {
     if (this.startInFlight) return this.startInFlight;
+
     const command = this.sttProvider
       ? this.resumeExistingProvider(this.sttProvider, this.sttGeneration)
       : this.startNewProvider();
+
     this.startInFlight = command;
-    const clearInFlight = () => { if (this.startInFlight === command) this.startInFlight = null; };
-    command.then(clearInFlight, clearInFlight);
+    command.then(
+      () => this.clearStartInFlight(command),
+      () => this.clearStartInFlight(command),
+    );
     return command;
   }
 
   resume(): Promise<void> { return this.start(); }
-  activate(): void { this.activateSession(); }
+  activate(): void { this.setSessionActive(); }
 
   pause(): void {
     this.acceptingTranscript = false;
     const provider = this.sttProvider;
     if (provider) void Promise.resolve(provider.pause()).catch(() => {});
-    this.pauseSession({ sttStatus: 'idle' });
+    this.setSessionPaused({ sttStatus: 'idle' });
   }
 
   stop(): void {
     const provider = this.invalidateStt();
     if (provider) void this.stopProvider(provider);
-    this.stopSession({ sttStatus: 'idle', sttError: null, sttProviderName: '' });
+    this.resetSession({ sttStatus: 'idle', sttError: null, sttProviderName: '' });
   }
 
   dispose(): void {
@@ -125,7 +137,7 @@ export class SessionRuntime {
 
     const cardsChanged = nextCards !== this.snapshot.cards;
     if (!cardsChanged && !recentDetectionsChanged) return;
-    const snapshotPatch: Partial<SessionRuntimeSnapshot> = {};
+    const snapshotPatch: SnapshotPatch = {};
     if (cardsChanged) snapshotPatch.cards = nextCards;
     if (recentDetectionsChanged) snapshotPatch.recentDetections = detectedEntities;
     this.updateSnapshot(snapshotPatch);
@@ -170,7 +182,7 @@ export class SessionRuntime {
         return;
       }
       this.acceptingTranscript = true;
-      this.activateSession({ sttStatus: 'active', sttError: null });
+      this.setSessionActive({ sttStatus: 'active', sttError: null });
     } catch (e) {
       if (this.sttGeneration !== generation) return;
       const provider = this.sttProvider;
@@ -190,13 +202,13 @@ export class SessionRuntime {
       await Promise.resolve(provider.resume());
       if (this.sttGeneration !== generation || this.sttProvider !== provider) return;
       this.acceptingTranscript = true;
-      this.activateSession({ sttStatus: 'active', sttError: null });
+      this.setSessionActive({ sttStatus: 'active', sttError: null });
     } catch (e) {
       if (this.sttGeneration !== generation || this.sttProvider !== provider) return;
       this.acceptingTranscript = false;
       await this.stopProvider(provider);
       if (this.sttProvider === provider) this.sttProvider = null;
-      this.pauseSession({
+      this.setSessionPaused({
         sttError: `Failed to resume mic: ${this.formatError(e)}`,
         sttStatus: 'error',
       });
@@ -213,25 +225,25 @@ export class SessionRuntime {
     const provider = this.sttProvider;
     if (provider) void this.stopProvider(provider);
     this.sttProvider = null;
-    const patch = { sttError: error, sttStatus: 'error' as SttStatus };
-    if (this.snapshot.status === 'active') this.pauseSession(patch);
+    const patch: SnapshotPatch = { sttError: error, sttStatus: 'error' };
+    if (this.snapshot.status === 'active') this.setSessionPaused(patch);
     else this.updateSnapshot(patch);
   }
 
-  private activateSession(patch: Partial<SessionRuntimeSnapshot> = {}): void {
+  private setSessionActive(patch: SnapshotPatch = {}): void {
     this.processedTranscriptLength = this.snapshot.transcript.length;
     this.previousDetectionContext = '';
     this.startDetectionInterval();
     this.updateSnapshot({ status: 'active', ...patch });
   }
 
-  private pauseSession(patch: Partial<SessionRuntimeSnapshot> = {}): void {
+  private setSessionPaused(patch: SnapshotPatch = {}): void {
     this.previousDetectionContext = '';
     this.clearDetectionInterval();
     this.updateSnapshot({ status: 'paused', ...patch });
   }
 
-  private stopSession(patch: Partial<SessionRuntimeSnapshot> = {}): void {
+  private resetSession(patch: SnapshotPatch = {}): void {
     this.processedTranscriptLength = 0;
     this.previousDetectionContext = '';
     this.lastDetectionKey = '';
@@ -252,6 +264,10 @@ export class SessionRuntime {
     this.detectionInterval = null;
   }
 
+  private clearStartInFlight(command: Promise<void>): void {
+    if (this.startInFlight === command) this.startInFlight = null;
+  }
+
   private invalidateStt(): STTProvider | null {
     this.sttGeneration += 1;
     this.startInFlight = null;
@@ -267,7 +283,7 @@ export class SessionRuntime {
 
   private formatError(error: unknown): string { return error instanceof Error ? error.message : String(error); }
 
-  private updateSnapshot(patch: Partial<SessionRuntimeSnapshot>): void {
+  private updateSnapshot(patch: SnapshotPatch): void {
     if (Object.keys(patch).length === 0) return;
     this.snapshot = { ...this.snapshot, ...patch };
     this.notifyListeners();

--- a/src/context/session.tsx
+++ b/src/context/session.tsx
@@ -30,9 +30,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
   const [sttProviderName, setSttProviderName] = useState('');
   const [entityStatus, setEntityStatus] = useState<EntityStatus>('loading');
   const [entities, setEntities] = useState<EntityIndex>([]);
-  const runtimeRef = useRef<SessionRuntime | null>(null);
-  if (!runtimeRef.current) runtimeRef.current = new SessionRuntime();
-  const runtime = runtimeRef.current;
+  const [runtime] = useState(() => new SessionRuntime());
   const [runtimeSnapshot, setRuntimeSnapshot] = useState(() => runtime.getSnapshot());
   const { status, cards, transcript, recentDetections } = runtimeSnapshot;
   const sttRef = useRef<STTProvider | null>(null);

--- a/src/context/session.tsx
+++ b/src/context/session.tsx
@@ -1,14 +1,6 @@
-import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 import type { EntityIndex, WorldDataProvider } from '../entities';
-import { useDataSources } from './data-sources';
-import {
-  DETECT_INTERVAL_MS,
-  loadSettings,
-  buildProvider,
-} from './session-helpers';
-import { SessionRuntime } from './session-runtime';
-import type { SttStatus, EntityStatus, SessionContextType } from './session-types';
 import { EntityDetector } from '../entities/detector';
 import { FileUploadProvider } from '../entities/providers/file-upload';
 import { GoogleDocsProvider } from '../entities/providers/google-docs';
@@ -18,27 +10,28 @@ import { MarkdownProvider } from '../entities/providers/markdown';
 import { NotionProvider, extractNotionId } from '../entities/providers/notion';
 import { SRDProvider } from '../entities/providers/srd';
 import { SAMPLE_WORLD } from '../sample-world';
-import type { STTProvider } from '../stt/index';
+import { useDataSources } from './data-sources';
+import { DETECT_INTERVAL_MS, buildProvider, loadSettings } from './session-helpers';
+import { SessionRuntime } from './session-runtime';
+import type { EntityStatus, SessionContextType } from './session-types';
 export { SessionStatus, SttStatus, EntityStatus, CardState } from './session-types';
 
 const SessionContext = createContext<SessionContextType | null>(null);
 
 export function SessionProvider({ children }: { children: React.ReactNode }) {
   const { settings: ds, uploadsVersion } = useDataSources();
-  const [sttStatus, setSttStatus] = useState<SttStatus>('idle');
-  const [sttError, setSttError] = useState<string | null>(null);
-  const [sttProviderName, setSttProviderName] = useState('');
   const [entityStatus, setEntityStatus] = useState<EntityStatus>('loading');
   const [entities, setEntities] = useState<EntityIndex>([]);
-  const [runtime] = useState(() => new SessionRuntime());
+  const [runtime] = useState(() => new SessionRuntime({
+    loadSttSettings: loadSettings,
+    buildSttProvider: buildProvider,
+    detectIntervalMs: DETECT_INTERVAL_MS,
+  }));
   const [runtimeSnapshot, setRuntimeSnapshot] = useState(() => runtime.getSnapshot());
-  const { status, cards, transcript, recentDetections } = runtimeSnapshot;
-  const sttRef = useRef<STTProvider | null>(null);
-  const sttGenerationRef = useRef(0);
-  const startInFlightRef = useRef<Promise<void> | null>(null);
-  const acceptingTranscriptRef = useRef(false);
+  const { status, sttStatus, sttError, sttProviderName, cards, transcript, recentDetections } = runtimeSnapshot;
 
   useEffect(() => runtime.subscribe(setRuntimeSnapshot), [runtime]);
+  useEffect(() => () => runtime.dispose(), [runtime]);
 
   useEffect(() => {
     let cancelled = false;
@@ -76,151 +69,13 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     return () => { cancelled = true; };
   }, [ds.srdEnabled, ds.srdSources.join(','), ds.kankaToken, ds.kankaCampaignId, ds.homebreweryUrl, ds.notionToken, ds.notionPageIds, ds.googleDocsUrl, uploadsVersion, runtime]);
 
-  useEffect(() => {
-    if (status !== 'active') return;
-
-    const interval = setInterval(() => {
-      runtime.processTranscript();
-    }, DETECT_INTERVAL_MS);
-
-    return () => clearInterval(interval);
-  }, [runtime, status]);
-
-  const appendTranscript = useCallback((text: string) => {
-    runtime.appendTranscript(text);
-  }, [runtime]);
-
-  const start = useCallback(async () => {
-    if (startInFlightRef.current) return;
-
-    if (sttRef.current) {
-      const generation = sttGenerationRef.current;
-      const provider = sttRef.current;
-      const resumePromise = Promise.resolve()
-        .then(() => provider.resume())
-        .then(() => {
-          if (sttGenerationRef.current !== generation || sttRef.current !== provider) return;
-          acceptingTranscriptRef.current = true;
-          runtime.activate();
-          setSttStatus('active');
-        })
-        .catch((e) => {
-          if (sttGenerationRef.current !== generation || sttRef.current !== provider) return;
-          acceptingTranscriptRef.current = false;
-          Promise.resolve(provider.stop()).catch(() => {});
-          sttRef.current = null;
-          setSttError(`Failed to resume mic: ${e instanceof Error ? e.message : String(e)}`);
-          setSttStatus('error');
-          runtime.pause();
-        })
-        .finally(() => {
-          if (startInFlightRef.current === resumePromise) startInFlightRef.current = null;
-        });
-      startInFlightRef.current = resumePromise;
-      return;
-    }
-
-    const generation = sttGenerationRef.current + 1;
-    sttGenerationRef.current = generation;
-    acceptingTranscriptRef.current = false;
-    setSttStatus('connecting');
-    setSttError(null);
-
-    const startPromise = (async () => {
-      const settings = await loadSettings();
-      if (sttGenerationRef.current !== generation) return;
-
-      const provider = buildProvider(
-        settings,
-        (text) => {
-          if (sttGenerationRef.current === generation && acceptingTranscriptRef.current) {
-            appendTranscript(text);
-          }
-        },
-        (err) => {
-          if (sttGenerationRef.current !== generation) return;
-          acceptingTranscriptRef.current = false;
-          const current = sttRef.current;
-          if (current) Promise.resolve(current.stop()).catch(() => {});
-          sttRef.current = null;
-          setSttError(err);
-          setSttStatus('error');
-          if (runtime.getSnapshot().status === 'active') runtime.pause();
-        },
-      );
-
-      sttRef.current = provider;
-      setSttProviderName(provider.name);
-
-      await provider.start();
-      if (sttGenerationRef.current !== generation || sttRef.current !== provider) {
-        await provider.stop();
-        return;
-      }
-
-      acceptingTranscriptRef.current = true;
-      setSttStatus('active');
-      runtime.activate();
-    })()
-      .catch((e) => {
-        if (sttGenerationRef.current !== generation) return;
-        const provider = sttRef.current;
-        if (provider) Promise.resolve(provider.stop()).catch(() => {});
-        sttRef.current = null;
-        acceptingTranscriptRef.current = false;
-        setSttProviderName('');
-        setSttError(`Failed to start mic: ${e instanceof Error ? e.message : String(e)}`);
-        setSttStatus('error');
-      })
-      .finally(() => {
-        if (startInFlightRef.current === startPromise) startInFlightRef.current = null;
-      });
-
-    startInFlightRef.current = startPromise;
-  }, [appendTranscript, runtime]);
-
-  const pause = useCallback(() => {
-    acceptingTranscriptRef.current = false;
-    const provider = sttRef.current;
-    if (provider) Promise.resolve(provider.pause()).catch(() => {});
-    setSttStatus('idle');
-    runtime.pause();
-  }, [runtime]);
-
-  const stop = useCallback(() => {
-    sttGenerationRef.current += 1;
-    startInFlightRef.current = null;
-    acceptingTranscriptRef.current = false;
-    const provider = sttRef.current;
-    if (provider) Promise.resolve(provider.stop()).catch(() => {});
-    sttRef.current = null;
-    setSttStatus('idle');
-    setSttError(null);
-    setSttProviderName('');
-    runtime.stop();
-  }, [runtime]);
-
-  useEffect(() => {
-    return () => {
-      sttGenerationRef.current += 1;
-      acceptingTranscriptRef.current = false;
-      const provider = sttRef.current;
-      if (provider) Promise.resolve(provider.stop()).catch(() => {});
-      sttRef.current = null;
-    };
-  }, []);
-
-  const pin = useCallback((instanceId: string) => {
-    runtime.pin(instanceId);
-  }, [runtime]);
-
-  const unpin = useCallback((instanceId: string) => {
-    runtime.unpin(instanceId);
-  }, [runtime]);
-
-  const dismiss = useCallback((instanceId: string) => {
-    runtime.dismiss(instanceId);
-  }, [runtime]);
+  const start = useCallback(() => { void runtime.start(); }, [runtime]);
+  const pause = useCallback(() => { runtime.pause(); }, [runtime]);
+  const stop = useCallback(() => { runtime.stop(); }, [runtime]);
+  const appendTranscript = useCallback((text: string) => { runtime.appendTranscript(text); }, [runtime]);
+  const pin = useCallback((instanceId: string) => { runtime.pin(instanceId); }, [runtime]);
+  const unpin = useCallback((instanceId: string) => { runtime.unpin(instanceId); }, [runtime]);
+  const dismiss = useCallback((instanceId: string) => { runtime.dismiss(instanceId); }, [runtime]);
 
   return (
     <SessionContext.Provider value={{

--- a/src/context/session.tsx
+++ b/src/context/session.tsx
@@ -1,19 +1,14 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
-import { Entity, EntityIndex, WorldDataProvider } from '../entities';
+import type { EntityIndex, WorldDataProvider } from '../entities';
 import { useDataSources } from './data-sources';
-import { buildDetectionInput, nextDetectionContext } from './detection-window';
 import {
-  MAX_CARDS,
   DETECT_INTERVAL_MS,
-  addCard,
-  pinCard,
-  unpinCard,
-  dismissCard,
   loadSettings,
   buildProvider,
 } from './session-helpers';
-import { SessionStatus, SttStatus, EntityStatus, CardState, SessionContextType } from './session-types';
+import { SessionRuntime } from './session-runtime';
+import type { SttStatus, EntityStatus, SessionContextType } from './session-types';
 import { EntityDetector } from '../entities/detector';
 import { FileUploadProvider } from '../entities/providers/file-upload';
 import { GoogleDocsProvider } from '../entities/providers/google-docs';
@@ -23,31 +18,29 @@ import { MarkdownProvider } from '../entities/providers/markdown';
 import { NotionProvider, extractNotionId } from '../entities/providers/notion';
 import { SRDProvider } from '../entities/providers/srd';
 import { SAMPLE_WORLD } from '../sample-world';
-import { STTProvider } from '../stt/index';
+import type { STTProvider } from '../stt/index';
 export { SessionStatus, SttStatus, EntityStatus, CardState } from './session-types';
 
 const SessionContext = createContext<SessionContextType | null>(null);
 
 export function SessionProvider({ children }: { children: React.ReactNode }) {
   const { settings: ds, uploadsVersion } = useDataSources();
-  const [status, setStatus] = useState<SessionStatus>('idle');
   const [sttStatus, setSttStatus] = useState<SttStatus>('idle');
   const [sttError, setSttError] = useState<string | null>(null);
   const [sttProviderName, setSttProviderName] = useState('');
   const [entityStatus, setEntityStatus] = useState<EntityStatus>('loading');
-  const [cards, setCards] = useState<CardState[]>([]);
   const [entities, setEntities] = useState<EntityIndex>([]);
-  const [transcript, setTranscript] = useState('');
-  const [recentDetections, setRecentDetections] = useState<Entity[]>([]);
-  const detectorRef = useRef<EntityDetector | null>(null);
-  const transcriptRef = useRef('');
-  const processedUpToRef = useRef(0);
-  const detectionContextRef = useRef('');
-  const prevDetectionKeyRef = useRef('');
+  const runtimeRef = useRef<SessionRuntime | null>(null);
+  if (!runtimeRef.current) runtimeRef.current = new SessionRuntime();
+  const runtime = runtimeRef.current;
+  const [runtimeSnapshot, setRuntimeSnapshot] = useState(() => runtime.getSnapshot());
+  const { status, cards, transcript, recentDetections } = runtimeSnapshot;
   const sttRef = useRef<STTProvider | null>(null);
   const sttGenerationRef = useRef(0);
   const startInFlightRef = useRef<Promise<void> | null>(null);
   const acceptingTranscriptRef = useRef(false);
+
+  useEffect(() => runtime.subscribe(setRuntimeSnapshot), [runtime]);
 
   useEffect(() => {
     let cancelled = false;
@@ -78,52 +71,26 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
         });
         const combined = results.flatMap((r) => r.status === 'fulfilled' ? r.value : []);
         setEntities(combined);
-        detectorRef.current = new EntityDetector(combined);
+        runtime.setDetector(new EntityDetector(combined));
         setEntityStatus(combined.length > 0 ? 'ready' : 'error');
       });
 
     return () => { cancelled = true; };
-  }, [ds.srdEnabled, ds.srdSources.join(','), ds.kankaToken, ds.kankaCampaignId, ds.homebreweryUrl, ds.notionToken, ds.notionPageIds, ds.googleDocsUrl, uploadsVersion]);
+  }, [ds.srdEnabled, ds.srdSources.join(','), ds.kankaToken, ds.kankaCampaignId, ds.homebreweryUrl, ds.notionToken, ds.notionPageIds, ds.googleDocsUrl, uploadsVersion, runtime]);
 
   useEffect(() => {
     if (status !== 'active') return;
 
     const interval = setInterval(() => {
-      const detector = detectorRef.current;
-      if (!detector) return;
-
-      const newText = transcriptRef.current.slice(processedUpToRef.current);
-      if (!newText.trim()) return;
-
-      const found = detector.detect(buildDetectionInput(detectionContextRef.current, newText));
-      processedUpToRef.current = transcriptRef.current.length;
-      detectionContextRef.current = nextDetectionContext(transcriptRef.current);
-
-      if (found.length === 0) return;
-
-      const detectionKey = found.map((e) => e.id).join(',');
-      if (detectionKey !== prevDetectionKeyRef.current) {
-        prevDetectionKeyRef.current = detectionKey;
-        setRecentDetections(found);
-      }
-
-      setCards((prev) => {
-        let next = prev;
-        found.forEach((entity) => { next = addCard(next, entity); });
-        return next;
-      });
+      runtime.processTranscript();
     }, DETECT_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [status]);
+  }, [runtime, status]);
 
   const appendTranscript = useCallback((text: string) => {
-    setTranscript((prev) => {
-      const next = prev ? `${prev} ${text}` : text;
-      transcriptRef.current = next;
-      return next;
-    });
-  }, []);
+    runtime.appendTranscript(text);
+  }, [runtime]);
 
   const start = useCallback(async () => {
     if (startInFlightRef.current) return;
@@ -136,10 +103,8 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
         .then(() => {
           if (sttGenerationRef.current !== generation || sttRef.current !== provider) return;
           acceptingTranscriptRef.current = true;
-          setStatus('active');
+          runtime.activate();
           setSttStatus('active');
-          processedUpToRef.current = transcriptRef.current.length;
-          detectionContextRef.current = '';
         })
         .catch((e) => {
           if (sttGenerationRef.current !== generation || sttRef.current !== provider) return;
@@ -148,7 +113,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
           sttRef.current = null;
           setSttError(`Failed to resume mic: ${e instanceof Error ? e.message : String(e)}`);
           setSttStatus('error');
-          setStatus('paused');
+          runtime.pause();
         })
         .finally(() => {
           if (startInFlightRef.current === resumePromise) startInFlightRef.current = null;
@@ -160,7 +125,6 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     const generation = sttGenerationRef.current + 1;
     sttGenerationRef.current = generation;
     acceptingTranscriptRef.current = false;
-    detectionContextRef.current = '';
     setSttStatus('connecting');
     setSttError(null);
 
@@ -183,7 +147,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
           sttRef.current = null;
           setSttError(err);
           setSttStatus('error');
-          setStatus((prev) => prev === 'active' ? 'paused' : prev);
+          if (runtime.getSnapshot().status === 'active') runtime.pause();
         },
       );
 
@@ -198,9 +162,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
 
       acceptingTranscriptRef.current = true;
       setSttStatus('active');
-      setStatus('active');
-      processedUpToRef.current = transcriptRef.current.length;
-      detectionContextRef.current = '';
+      runtime.activate();
     })()
       .catch((e) => {
         if (sttGenerationRef.current !== generation) return;
@@ -217,16 +179,15 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
       });
 
     startInFlightRef.current = startPromise;
-  }, [appendTranscript]);
+  }, [appendTranscript, runtime]);
 
   const pause = useCallback(() => {
     acceptingTranscriptRef.current = false;
-    detectionContextRef.current = '';
     const provider = sttRef.current;
     if (provider) Promise.resolve(provider.pause()).catch(() => {});
     setSttStatus('idle');
-    setStatus('paused');
-  }, []);
+    runtime.pause();
+  }, [runtime]);
 
   const stop = useCallback(() => {
     sttGenerationRef.current += 1;
@@ -238,15 +199,8 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     setSttStatus('idle');
     setSttError(null);
     setSttProviderName('');
-    setStatus('idle');
-    setCards([]);
-    setTranscript('');
-    transcriptRef.current = '';
-    setRecentDetections([]);
-    prevDetectionKeyRef.current = '';
-    processedUpToRef.current = 0;
-    detectionContextRef.current = '';
-  }, []);
+    runtime.stop();
+  }, [runtime]);
 
   useEffect(() => {
     return () => {
@@ -259,16 +213,16 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const pin = useCallback((instanceId: string) => {
-    setCards((prev) => pinCard(prev, instanceId));
-  }, []);
+    runtime.pin(instanceId);
+  }, [runtime]);
 
   const unpin = useCallback((instanceId: string) => {
-    setCards((prev) => unpinCard(prev, instanceId));
-  }, []);
+    runtime.unpin(instanceId);
+  }, [runtime]);
 
   const dismiss = useCallback((instanceId: string) => {
-    setCards((prev) => dismissCard(prev, instanceId));
-  }, []);
+    runtime.dismiss(instanceId);
+  }, [runtime]);
 
   return (
     <SessionContext.Provider value={{

--- a/src/context/session.tsx
+++ b/src/context/session.tsx
@@ -30,8 +30,15 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
   const [runtimeSnapshot, setRuntimeSnapshot] = useState(() => runtime.getSnapshot());
   const { status, sttStatus, sttError, sttProviderName, cards, transcript, recentDetections } = runtimeSnapshot;
 
-  useEffect(() => runtime.subscribe(setRuntimeSnapshot), [runtime]);
-  useEffect(() => () => runtime.dispose(), [runtime]);
+  useEffect(() => {
+    return runtime.subscribe(setRuntimeSnapshot);
+  }, [runtime]);
+
+  useEffect(() => {
+    return () => {
+      runtime.dispose();
+    };
+  }, [runtime]);
 
   useEffect(() => {
     let cancelled = false;
@@ -69,13 +76,33 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     return () => { cancelled = true; };
   }, [ds.srdEnabled, ds.srdSources.join(','), ds.kankaToken, ds.kankaCampaignId, ds.homebreweryUrl, ds.notionToken, ds.notionPageIds, ds.googleDocsUrl, uploadsVersion, runtime]);
 
-  const start = useCallback(() => { void runtime.start(); }, [runtime]);
-  const pause = useCallback(() => { runtime.pause(); }, [runtime]);
-  const stop = useCallback(() => { runtime.stop(); }, [runtime]);
-  const appendTranscript = useCallback((text: string) => { runtime.appendTranscript(text); }, [runtime]);
-  const pin = useCallback((instanceId: string) => { runtime.pin(instanceId); }, [runtime]);
-  const unpin = useCallback((instanceId: string) => { runtime.unpin(instanceId); }, [runtime]);
-  const dismiss = useCallback((instanceId: string) => { runtime.dismiss(instanceId); }, [runtime]);
+  const start = useCallback(() => {
+    void runtime.start();
+  }, [runtime]);
+
+  const pause = useCallback(() => {
+    runtime.pause();
+  }, [runtime]);
+
+  const stop = useCallback(() => {
+    runtime.stop();
+  }, [runtime]);
+
+  const appendTranscript = useCallback((text: string) => {
+    runtime.appendTranscript(text);
+  }, [runtime]);
+
+  const pin = useCallback((instanceId: string) => {
+    runtime.pin(instanceId);
+  }, [runtime]);
+
+  const unpin = useCallback((instanceId: string) => {
+    runtime.unpin(instanceId);
+  }, [runtime]);
+
+  const dismiss = useCallback((instanceId: string) => {
+    runtime.dismiss(instanceId);
+  }, [runtime]);
 
   return (
     <SessionContext.Provider value={{

--- a/src/context/ui-settings.tsx
+++ b/src/context/ui-settings.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { Platform, useColorScheme } from 'react-native';
 
+import { CARD_SIZE_LAYOUT_CONFIGS, type CardSize, type CardSizeLayoutConfig } from '../reference-card-layout';
 import {
   createAppDataWriteToken,
   getAppDataItem,
@@ -10,20 +11,18 @@ import {
 import { CARD_SIZE_KEY, COLOR_SCHEME_KEY } from '../storage/keys';
 import { Colors, DARK, LIGHT } from '../theme';
 
-export type CardSize = 'S' | 'M' | 'L' | 'XL';
+export type { CardSize } from '../reference-card-layout';
 export type ColorScheme = 'dark' | 'light' | 'system';
 
-export interface CardSizeConfig {
-  landscapeCols: number;
-  portraitCols: number;
+export interface CardSizeConfig extends CardSizeLayoutConfig {
   fontScale: number;
 }
 
 export const CARD_SIZE_CONFIGS: Record<CardSize, CardSizeConfig> = {
-  S:  { landscapeCols: 4, portraitCols: 3, fontScale: 0.85 },
-  M:  { landscapeCols: 3, portraitCols: 2, fontScale: 1.0 },
-  L:  { landscapeCols: 2, portraitCols: 2, fontScale: 1.15 },
-  XL: { landscapeCols: 2, portraitCols: 1, fontScale: 1.35 },
+  S:  { ...CARD_SIZE_LAYOUT_CONFIGS.S, fontScale: 0.85 },
+  M:  { ...CARD_SIZE_LAYOUT_CONFIGS.M, fontScale: 1.0 },
+  L:  { ...CARD_SIZE_LAYOUT_CONFIGS.L, fontScale: 1.15 },
+  XL: { ...CARD_SIZE_LAYOUT_CONFIGS.XL, fontScale: 1.35 },
 };
 
 export { CARD_SIZE_KEY, COLOR_SCHEME_KEY } from '../storage/keys';

--- a/src/context/ui-settings.tsx
+++ b/src/context/ui-settings.tsx
@@ -1,7 +1,12 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { Platform, useColorScheme } from 'react-native';
 
-import { CARD_SIZE_LAYOUT_CONFIGS, type CardSize, type CardSizeLayoutConfig } from '../reference-card-layout';
+import {
+  CARD_SIZE_LAYOUT_CONFIGS,
+  isCardSize,
+  type CardSize,
+  type CardSizeLayoutConfig,
+} from '../reference-card-layout';
 import {
   createAppDataWriteToken,
   getAppDataItem,
@@ -11,8 +16,11 @@ import {
 import { CARD_SIZE_KEY, COLOR_SCHEME_KEY } from '../storage/keys';
 import { Colors, DARK, LIGHT } from '../theme';
 
+export { CARD_SIZES } from '../reference-card-layout';
 export type { CardSize } from '../reference-card-layout';
-export type ColorScheme = 'dark' | 'light' | 'system';
+
+export const COLOR_SCHEMES = ['system', 'dark', 'light'] as const;
+export type ColorScheme = (typeof COLOR_SCHEMES)[number];
 
 export interface CardSizeConfig extends CardSizeLayoutConfig {
   fontScale: number;
@@ -29,13 +37,17 @@ export { CARD_SIZE_KEY, COLOR_SCHEME_KEY } from '../storage/keys';
 export const DEFAULT_CARD_SIZE: CardSize = 'M';
 export const DEFAULT_COLOR_SCHEME: ColorScheme = 'dark';
 
+function isColorScheme(value: unknown): value is ColorScheme {
+  return typeof value === 'string' && (COLOR_SCHEMES as readonly string[]).includes(value);
+}
+
 // Read synchronously from localStorage on web so the first render matches
 // the stored preference -- avoids SSR/client hydration mismatch.
 function readStoredColorScheme(): ColorScheme {
   if (Platform.OS === 'web' && typeof window !== 'undefined') {
     try {
-      const v = window.localStorage.getItem(COLOR_SCHEME_KEY);
-      if (v === 'dark' || v === 'light' || v === 'system') return v;
+      const value = window.localStorage.getItem(COLOR_SCHEME_KEY);
+      if (isColorScheme(value)) return value;
     } catch {}
   }
   return DEFAULT_COLOR_SCHEME;
@@ -44,8 +56,8 @@ function readStoredColorScheme(): ColorScheme {
 function readStoredCardSize(): CardSize {
   if (Platform.OS === 'web' && typeof window !== 'undefined') {
     try {
-      const v = window.localStorage.getItem(CARD_SIZE_KEY);
-      if (v && v in CARD_SIZE_CONFIGS) return v as CardSize;
+      const value = window.localStorage.getItem(CARD_SIZE_KEY);
+      if (isCardSize(value)) return value;
     } catch {}
   }
   return DEFAULT_CARD_SIZE;
@@ -74,14 +86,12 @@ export function UISettingsProvider({ children }: { children: React.ReactNode }) 
         getAppDataItem(COLOR_SCHEME_KEY, token),
       ]).then(([rawSize, rawScheme]) => {
         try {
-          if (rawSize && rawSize in CARD_SIZE_CONFIGS) setCardSizeState(rawSize as CardSize);
+          if (isCardSize(rawSize)) setCardSizeState(rawSize);
         } catch (e) {
           console.warn('[dnd-ref] Failed to parse card size preference:', e);
         }
         try {
-          if (rawScheme === 'dark' || rawScheme === 'light' || rawScheme === 'system') {
-            setColorSchemeState(rawScheme);
-          }
+          if (isColorScheme(rawScheme)) setColorSchemeState(rawScheme);
         } catch (e) {
           console.warn('[dnd-ref] Failed to parse color scheme preference:', e);
         }

--- a/src/entities/ingestion.test.ts
+++ b/src/entities/ingestion.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ingestJsonContent,
+  ingestMarkdownContent,
+  normalizeIngestedEntity,
+} from './ingestion';
+
+describe('world data ingestion', () => {
+  it('normalizes entity type, ids, aliases, and summaries for shared ingested records', () => {
+    expect(normalizeIngestedEntity({
+      name: ' The Argent Key! ',
+      type: 'artifact weapon',
+      aliases: [' key ', '', 7, 'silver key'],
+      description: '  Opens the Moon Door.  ',
+    }, { idPrefix: 'upload', idNamespace: 42, index: 3 })).toEqual({
+      id: 'upload-the-argent-key-42-3',
+      name: 'The Argent Key!',
+      type: 'Item',
+      aliases: ['key', 'silver key'],
+      summary: 'Opens the Moon Door.',
+    });
+  });
+
+  it('keeps markdown/text parsing behavior while using shared normalization', () => {
+    const entities = ingestMarkdownContent(`
+## Moonlit Bazaar
+Type: place
+Aliases: Night Market; Bazaar | moon market
+
+Open only under the new moon.
+
+### Captain Aria
+**Type:** character
+**Aliases:** Aria, the captain
+
+Commands the east watch.
+`);
+
+    expect(entities).toEqual([
+      {
+        id: 'moonlit-bazaar',
+        name: 'Moonlit Bazaar',
+        type: 'Location',
+        aliases: ['Night Market', 'Bazaar', 'moon market'],
+        summary: 'Open only under the new moon.',
+      },
+      {
+        id: 'captain-aria',
+        name: 'Captain Aria',
+        type: 'NPC',
+        aliases: ['Aria', 'the captain'],
+        summary: 'Commands the east watch.',
+      },
+    ]);
+  });
+
+  it('ingests JSON arrays with upload-style ids and description fallback summaries', () => {
+    const entities = ingestJsonContent(JSON.stringify([
+      {
+        name: 'Lady Seraphine Voss',
+        type: 'person',
+        aliases: ['Seraphine', ' Lady Voss '],
+        description: 'Spymaster of the Dawnwarden Order.',
+      },
+      { name: '', type: 'npc' },
+      { nope: 'missing name' },
+    ]), { idPrefix: 'upload', idNamespace: 1234 });
+
+    expect(entities).toEqual([
+      {
+        id: 'upload-lady-seraphine-voss-1234-0',
+        name: 'Lady Seraphine Voss',
+        type: 'NPC',
+        aliases: ['Seraphine', 'Lady Voss'],
+        summary: 'Spymaster of the Dawnwarden Order.',
+      },
+    ]);
+  });
+});

--- a/src/entities/ingestion.ts
+++ b/src/entities/ingestion.ts
@@ -1,0 +1,223 @@
+import {
+  Entity,
+  EntityIndex,
+  EntityType,
+  normalizeEntityType,
+  slugify,
+} from './index';
+
+interface MarkdownBlock {
+  name: string;
+  body: string;
+}
+
+export interface IngestedEntityRecord {
+  name?: unknown;
+  type?: unknown;
+  aliases?: unknown;
+  summary?: unknown;
+  description?: unknown;
+  image?: unknown;
+}
+
+export interface NormalizeIngestedEntityOptions {
+  idPrefix?: string;
+  idNamespace?: string | number;
+  index?: number;
+}
+
+export interface UploadedWorldData {
+  name: string;
+  content: string;
+}
+
+export interface UploadedWorldDataIngestionOptions {
+  idNamespace?: string | number;
+  onJsonParseError?: (error: unknown) => void;
+}
+
+export function normalizeIngestedEntity(
+  record: IngestedEntityRecord,
+  options: NormalizeIngestedEntityOptions = {},
+): Entity | null {
+  const name = normalizeName(record.name);
+  if (!name) return null;
+
+  const entity: Entity = {
+    id: buildEntityId(name, options),
+    name,
+    type: normalizeIngestedEntityType(record.type),
+    aliases: normalizeAliases(record.aliases),
+    summary: normalizeSummary(record.summary, record.description),
+  };
+
+  if (typeof record.image === 'string' && record.image.trim()) {
+    entity.image = record.image.trim();
+  }
+
+  return entity;
+}
+
+export function ingestMarkdownContent(content: string): EntityIndex {
+  const blocks = getHeadingBlocks(content);
+  const sourceBlocks = blocks.length > 0 ? blocks : getFallbackBlock(content);
+
+  return sourceBlocks
+    .map((block) => normalizeMarkdownBlock(block))
+    .filter((entity): entity is Entity => entity !== null);
+}
+
+export function ingestJsonContent(
+  content: string,
+  options: Omit<NormalizeIngestedEntityOptions, 'index'> = {},
+): EntityIndex {
+  const data = JSON.parse(content) as unknown;
+  const items = Array.isArray(data) ? data : [];
+  const entities: EntityIndex = [];
+
+  for (const item of items) {
+    if (!isIngestedEntityRecord(item)) continue;
+
+    const entity = normalizeIngestedEntity(item, {
+      ...options,
+      index: entities.length,
+    });
+    if (entity) entities.push(entity);
+  }
+
+  return entities;
+}
+
+export function ingestUploadedFile(
+  upload: UploadedWorldData,
+  options: UploadedWorldDataIngestionOptions = {},
+): EntityIndex {
+  if (isJsonUploadName(upload.name)) {
+    try {
+      return ingestJsonContent(upload.content, {
+        idPrefix: 'upload',
+        idNamespace: options.idNamespace ?? Date.now(),
+      });
+    } catch (error) {
+      options.onJsonParseError?.(error);
+    }
+  }
+
+  return ingestMarkdownContent(upload.content);
+}
+
+export function isJsonUploadName(name: string): boolean {
+  return name.toLowerCase().endsWith('.json');
+}
+
+function normalizeMarkdownBlock(block: MarkdownBlock): Entity | null {
+  const name = cleanHeading(block.name);
+  let type = '';
+  let aliases = '';
+  const summaryLines: string[] = [];
+
+  for (const line of block.body.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '---') continue;
+
+    const field = parseField(trimmed);
+    if (field?.key === 'type') {
+      type = field.value;
+      continue;
+    }
+    if (field?.key === 'aliases') {
+      aliases = field.value;
+      continue;
+    }
+
+    if (!trimmed && summaryLines.length === 0) continue;
+    summaryLines.push(line);
+  }
+
+  return normalizeIngestedEntity({
+    name,
+    type,
+    aliases,
+    summary: summaryLines.join('\n'),
+  });
+}
+
+function getHeadingBlocks(content: string): MarkdownBlock[] {
+  const headingRe = /^(#{1,3})\s+(.+?)\s*#*\s*$/gm;
+  const matches = Array.from(content.matchAll(headingRe));
+
+  return matches.map((match, i) => {
+    const start = (match.index ?? 0) + match[0].length;
+    const end = matches[i + 1]?.index ?? content.length;
+    return { name: match[2], body: content.slice(start, end) };
+  });
+}
+
+function getFallbackBlock(content: string): MarkdownBlock[] {
+  const lines = content.trim().split('\n');
+  const name = lines.shift()?.trim() ?? '';
+  return name ? [{ name, body: lines.join('\n') }] : [];
+}
+
+function cleanHeading(name: string): string {
+  return name.replace(/\*\*/g, '').trim();
+}
+
+function parseField(line: string): { key: string; value: string } | null {
+  const match = line.match(/^(?:[-*]\s*)?(?:\*\*)?([^:*]+):(?:\*\*)?\s*(.+)$/);
+  if (!match) return null;
+
+  return {
+    key: match[1].replace(/\*/g, '').trim().toLowerCase(),
+    value: match[2].trim(),
+  };
+}
+
+function isIngestedEntityRecord(value: unknown): value is IngestedEntityRecord {
+  return value !== null && typeof value === 'object';
+}
+
+function normalizeName(value: unknown): string | null {
+  return typeof value === 'string' ? value.trim() || null : null;
+}
+
+function normalizeIngestedEntityType(value: unknown): EntityType {
+  return normalizeEntityType(typeof value === 'string' ? value : '');
+}
+
+function normalizeAliases(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return splitAliasString(value);
+  }
+
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .filter((alias): alias is string => typeof alias === 'string')
+    .map((alias) => alias.trim())
+    .filter(Boolean);
+}
+
+function splitAliasString(value: string): string[] {
+  return value
+    .split(/[,;|]/)
+    .map((alias) => alias.trim())
+    .filter(Boolean);
+}
+
+function normalizeSummary(summary: unknown, description: unknown): string {
+  const value = typeof summary === 'string' ? summary : description;
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function buildEntityId(name: string, options: NormalizeIngestedEntityOptions): string {
+  const parts: Array<string | number> = [];
+  if (options.idPrefix) parts.push(options.idPrefix);
+  parts.push(slugify(name));
+  if (options.idNamespace !== undefined && options.idNamespace !== '') {
+    parts.push(options.idNamespace);
+  }
+  if (options.index !== undefined) parts.push(options.index);
+
+  return parts.join('-');
+}

--- a/src/entities/ingestion.ts
+++ b/src/entities/ingestion.ts
@@ -6,6 +6,9 @@ import {
   slugify,
 } from './index';
 
+const JSON_UPLOAD_EXTENSION = '.json';
+const UPLOAD_ENTITY_ID_PREFIX = 'upload';
+
 interface MarkdownBlock {
   name: string;
   body: string;
@@ -40,7 +43,7 @@ export function normalizeIngestedEntity(
   record: IngestedEntityRecord,
   options: NormalizeIngestedEntityOptions = {},
 ): Entity | null {
-  const name = normalizeName(record.name);
+  const name = normalizeNonEmptyString(record.name);
   if (!name) return null;
 
   const entity: Entity = {
@@ -51,9 +54,8 @@ export function normalizeIngestedEntity(
     summary: normalizeSummary(record.summary, record.description),
   };
 
-  if (typeof record.image === 'string' && record.image.trim()) {
-    entity.image = record.image.trim();
-  }
+  const image = normalizeNonEmptyString(record.image);
+  if (image) entity.image = image;
 
   return entity;
 }
@@ -95,7 +97,7 @@ export function ingestUploadedFile(
   if (isJsonUploadName(upload.name)) {
     try {
       return ingestJsonContent(upload.content, {
-        idPrefix: 'upload',
+        idPrefix: UPLOAD_ENTITY_ID_PREFIX,
         idNamespace: options.idNamespace ?? Date.now(),
       });
     } catch (error) {
@@ -107,13 +109,13 @@ export function ingestUploadedFile(
 }
 
 export function isJsonUploadName(name: string): boolean {
-  return name.toLowerCase().endsWith('.json');
+  return name.toLowerCase().endsWith(JSON_UPLOAD_EXTENSION);
 }
 
 function normalizeMarkdownBlock(block: MarkdownBlock): Entity | null {
   const name = cleanHeading(block.name);
-  let type = '';
-  let aliases = '';
+  let rawType = '';
+  let rawAliases = '';
   const summaryLines: string[] = [];
 
   for (const line of block.body.split('\n')) {
@@ -122,11 +124,11 @@ function normalizeMarkdownBlock(block: MarkdownBlock): Entity | null {
 
     const field = parseField(trimmed);
     if (field?.key === 'type') {
-      type = field.value;
+      rawType = field.value;
       continue;
     }
     if (field?.key === 'aliases') {
-      aliases = field.value;
+      rawAliases = field.value;
       continue;
     }
 
@@ -136,8 +138,8 @@ function normalizeMarkdownBlock(block: MarkdownBlock): Entity | null {
 
   return normalizeIngestedEntity({
     name,
-    type,
-    aliases,
+    type: rawType,
+    aliases: rawAliases,
     summary: summaryLines.join('\n'),
   });
 }
@@ -177,8 +179,11 @@ function isIngestedEntityRecord(value: unknown): value is IngestedEntityRecord {
   return value !== null && typeof value === 'object';
 }
 
-function normalizeName(value: unknown): string | null {
-  return typeof value === 'string' ? value.trim() || null : null;
+function normalizeNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const normalized = value.trim();
+  return normalized || null;
 }
 
 function normalizeIngestedEntityType(value: unknown): EntityType {

--- a/src/entities/providers/file-upload.test.ts
+++ b/src/entities/providers/file-upload.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const storage = vi.hoisted(() => new Map<string, string>());
 const storageControls = vi.hoisted(() => ({
@@ -21,7 +21,7 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
   },
 }));
 
-import { addUpload, getUploads, removeUpload } from './file-upload';
+import { addUpload, FileUploadProvider, getUploads, removeUpload } from './file-upload';
 import { resetAppDataControlsForTests, resetStoredAppData } from '../../storage/app-data';
 
 describe('file upload storage', () => {
@@ -29,6 +29,10 @@ describe('file upload storage', () => {
     storage.clear();
     storageControls.getItemGate = null;
     resetAppDataControlsForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('preserves every file when uploads are added concurrently', async () => {
@@ -85,5 +89,75 @@ describe('file upload storage', () => {
     storageControls.getItemGate = null;
 
     expect(await getUploads()).toEqual([]);
+  });
+
+  it('loads markdown, text, and JSON uploads through world data ingestion', async () => {
+    await addUpload('bazaar.md', `
+## Moonlit Bazaar
+Type: place
+Aliases: Night Market; Bazaar
+
+Open only under the new moon.
+`);
+    await addUpload('captain.txt', `Captain Aria
+Type: character
+Aliases: Aria | the captain
+
+Commands the east watch.`);
+    await addUpload('items.json', JSON.stringify([
+      {
+        name: 'The Sundering Blade',
+        type: 'artifact',
+        aliases: ['Sundering Blade', 'the blade'],
+        description: 'Can destroy a lich phylactery.',
+      },
+    ]));
+
+    const entities = await new FileUploadProvider().load();
+
+    expect(entities.map(({ name, type, aliases, summary }) => ({ name, type, aliases, summary }))).toEqual([
+      {
+        name: 'Moonlit Bazaar',
+        type: 'Location',
+        aliases: ['Night Market', 'Bazaar'],
+        summary: 'Open only under the new moon.',
+      },
+      {
+        name: 'Captain Aria',
+        type: 'NPC',
+        aliases: ['Aria', 'the captain'],
+        summary: 'Commands the east watch.',
+      },
+      {
+        name: 'The Sundering Blade',
+        type: 'Item',
+        aliases: ['Sundering Blade', 'the blade'],
+        summary: 'Can destroy a lich phylactery.',
+      },
+    ]);
+    expect(entities[2].id).toMatch(/^upload-the-sundering-blade-\d+-0$/);
+  });
+
+  it('falls back to markdown ingestion for invalid JSON uploads', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await addUpload('fallback.json', `
+# Lord Ember
+Type: npc
+Aliases: Ember
+
+Rules the cinder court.
+`);
+
+    const entities = await new FileUploadProvider().load();
+
+    expect(warn).toHaveBeenCalledWith('[dnd-ref] Failed to parse JSON upload: fallback.json');
+    expect(entities.map(({ name, type, aliases, summary }) => ({ name, type, aliases, summary }))).toEqual([
+      {
+        name: 'Lord Ember',
+        type: 'NPC',
+        aliases: ['Ember'],
+        summary: 'Rules the cinder court.',
+      },
+    ]);
   });
 });

--- a/src/entities/providers/file-upload.test.ts
+++ b/src/entities/providers/file-upload.test.ts
@@ -21,7 +21,7 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
   },
 }));
 
-import { addUpload, getUploads, removeUpload, waitForUploadMutations } from './file-upload';
+import { addUpload, getUploads, removeUpload } from './file-upload';
 import { resetAppDataControlsForTests, resetStoredAppData } from '../../storage/app-data';
 
 describe('file upload storage', () => {
@@ -78,7 +78,7 @@ describe('file upload storage', () => {
     const upload = addUpload('late.md', '# Late');
     await Promise.resolve();
 
-    const reset = resetStoredAppData({ beforeClear: waitForUploadMutations });
+    const reset = resetStoredAppData();
     releaseGetItem();
 
     await Promise.all([upload, reset]);

--- a/src/entities/providers/file-upload.ts
+++ b/src/entities/providers/file-upload.ts
@@ -32,14 +32,13 @@ export class FileUploadProvider implements WorldDataProvider {
 
   async load(): Promise<EntityIndex> {
     const uploads = await getUploads();
-    const results = await Promise.all(uploads.map(parseUpload));
-    return results.flat();
+    return uploads.flatMap(parseUpload);
   }
 
   getName(): string { return this.name; }
 }
 
-async function parseUpload(upload: UploadedFile): Promise<EntityIndex> {
+function parseUpload(upload: UploadedFile): EntityIndex {
   return ingestUploadedFile(upload, {
     onJsonParseError: () => {
       console.warn(`[dnd-ref] Failed to parse JSON upload: ${upload.name}`);

--- a/src/entities/providers/file-upload.ts
+++ b/src/entities/providers/file-upload.ts
@@ -1,58 +1,30 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-
+import {
+  addUploadedFile,
+  getUploadedFiles,
+  removeUploadedFile,
+  waitForUploadedFileMutations,
+  type UploadedFile,
+} from '../../storage/app-data';
 import { EntityIndex, WorldDataProvider, normalizeEntityType, slugify } from '../index';
 import { MarkdownProvider } from './markdown';
-import { canPersistAppData, createAppDataWriteToken } from '../../storage/app-data';
-import { UPLOADS_KEY } from '../../storage/keys';
 
 export { UPLOADS_KEY } from '../../storage/keys';
-let uploadMutationQueue: Promise<void> = Promise.resolve();
-
-export interface UploadedFile {
-  id: string;
-  name: string;
-  content: string;
-}
+export type { UploadedFile } from '../../storage/app-data';
 
 export async function getUploads(): Promise<UploadedFile[]> {
-  try {
-    const raw = await AsyncStorage.getItem(UPLOADS_KEY);
-    return raw ? (JSON.parse(raw) as UploadedFile[]) : [];
-  } catch (e) {
-    console.warn('[dnd-ref] Failed to read uploads from storage:', e);
-    return [];
-  }
+  return getUploadedFiles();
 }
 
 export async function addUpload(name: string, content: string): Promise<void> {
-  const token = createAppDataWriteToken();
-  await mutateUploads(token, (uploads) => {
-    const id = `upload-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-    return [...uploads, { id, name, content }];
-  });
+  await addUploadedFile(name, content);
 }
 
 export async function removeUpload(id: string): Promise<void> {
-  const token = createAppDataWriteToken();
-  await mutateUploads(token, (uploads) => uploads.filter((u) => u.id !== id));
+  await removeUploadedFile(id);
 }
 
 export async function waitForUploadMutations(): Promise<void> {
-  await uploadMutationQueue.catch(() => undefined);
-}
-
-function mutateUploads(token: number, mutator: (uploads: UploadedFile[]) => UploadedFile[]): Promise<void> {
-  const operation = uploadMutationQueue
-    .catch(() => undefined)
-    .then(async () => {
-      if (!canPersistAppData(token)) return;
-      const uploads = await getUploads();
-      if (!canPersistAppData(token)) return;
-      await AsyncStorage.setItem(UPLOADS_KEY, JSON.stringify(mutator(uploads)));
-    });
-
-  uploadMutationQueue = operation.catch(() => undefined);
-  return operation;
+  await waitForUploadedFileMutations();
 }
 
 export class FileUploadProvider implements WorldDataProvider {

--- a/src/entities/providers/file-upload.ts
+++ b/src/entities/providers/file-upload.ts
@@ -5,8 +5,8 @@ import {
   waitForUploadedFileMutations,
   type UploadedFile,
 } from '../../storage/app-data';
-import { EntityIndex, WorldDataProvider, normalizeEntityType, slugify } from '../index';
-import { MarkdownProvider } from './markdown';
+import { EntityIndex, WorldDataProvider } from '../index';
+import { ingestUploadedFile } from '../ingestion';
 
 export { UPLOADS_KEY } from '../../storage/keys';
 export type { UploadedFile } from '../../storage/app-data';
@@ -40,26 +40,9 @@ export class FileUploadProvider implements WorldDataProvider {
 }
 
 async function parseUpload(upload: UploadedFile): Promise<EntityIndex> {
-  if (upload.name.endsWith('.json')) {
-    try {
-      return parseJSON(upload.content);
-    } catch {
+  return ingestUploadedFile(upload, {
+    onJsonParseError: () => {
       console.warn(`[dnd-ref] Failed to parse JSON upload: ${upload.name}`);
-    }
-  }
-  return new MarkdownProvider(upload.content, upload.name).load();
-}
-
-function parseJSON(content: string): EntityIndex {
-  const data = JSON.parse(content) as unknown;
-  const items = Array.isArray(data) ? data : [];
-  return items
-    .filter((item): item is Record<string, unknown> => !!item && typeof (item as any).name === 'string')
-    .map((item, i) => ({
-      id: `upload-${slugify(item.name as string)}-${Date.now()}-${i}`,
-      name: item.name as string,
-      type: normalizeEntityType((item.type as string) ?? ''),
-      aliases: Array.isArray(item.aliases) ? (item.aliases as string[]) : [],
-      summary: ((item.summary ?? item.description ?? '') as string),
-    }));
+    },
+  });
 }

--- a/src/entities/providers/google-docs.test.ts
+++ b/src/entities/providers/google-docs.test.ts
@@ -1,12 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const platform = vi.hoisted(() => ({ OS: 'web' }));
 const fetchMock = vi.hoisted(() => vi.fn());
 const ingestionMocks = vi.hoisted(() => ({
   ingestMarkdownContent: vi.fn(),
 }));
 
-vi.mock('react-native', () => ({ Platform: platform }));
+vi.mock('react-native', () => ({ Platform: { OS: 'web' } }));
 vi.mock('../ingestion', () => ingestionMocks);
 
 import { ingestMarkdownContent } from '../ingestion';
@@ -20,7 +19,6 @@ const mockedIngestMarkdownContent = vi.mocked(ingestMarkdownContent);
 
 describe('GoogleDocsProvider', () => {
   beforeEach(() => {
-    platform.OS = 'web';
     fetchMock.mockReset();
     mockedIngestMarkdownContent.mockReset();
     vi.stubGlobal('fetch', fetchMock);
@@ -42,10 +40,10 @@ describe('GoogleDocsProvider', () => {
   });
 
   it('builds direct Google Docs export URLs for native callers', () => {
-    expect(buildGoogleDocsExportUrl(
-      'https://docs.google.com/document/d/doc_123/edit#heading=h.1',
-      null,
-    )).toBe('https://docs.google.com/document/d/doc_123/export?format=txt');
+    const documentUrl = 'https://docs.google.com/document/d/doc_123/edit#heading=h.1';
+
+    expect(buildGoogleDocsExportUrl(documentUrl, null))
+      .toBe('https://docs.google.com/document/d/doc_123/export?format=txt');
     expect(buildGoogleDocsExportUrl('doc_123', null))
       .toBe('https://docs.google.com/document/d/doc_123/export?format=txt');
   });
@@ -68,7 +66,9 @@ Open only under the new moon.
     fetchMock.mockResolvedValue(textResponse(documentText));
     mockedIngestMarkdownContent.mockReturnValue(ingestedEntities);
 
-    const entities = await new GoogleDocsProvider('https://docs.google.com/document/d/doc_123/edit').load();
+    const entities = await new GoogleDocsProvider(
+      'https://docs.google.com/document/d/doc_123/edit',
+    ).load();
 
     expect(mockedIngestMarkdownContent).toHaveBeenCalledOnce();
     expect(mockedIngestMarkdownContent).toHaveBeenCalledWith(documentText);
@@ -76,7 +76,7 @@ Open only under the new moon.
   });
 
   it('surfaces failed public document exports through the provider failure path', async () => {
-    fetchMock.mockResolvedValue(textResponse('', { ok: false, status: 403 }));
+    fetchMock.mockResolvedValue(textResponse('', 403));
 
     await expect(new GoogleDocsProvider('doc_123').load())
       .rejects.toThrow('Google Docs fetch failed: 403');
@@ -91,13 +91,6 @@ Open only under the new moon.
   });
 });
 
-function textResponse(
-  body: string,
-  init: { ok?: boolean; status?: number } = {},
-): Response {
-  return {
-    ok: init.ok ?? true,
-    status: init.status ?? 200,
-    text: vi.fn(async () => body),
-  } as unknown as Response;
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, { status });
 }

--- a/src/entities/providers/google-docs.test.ts
+++ b/src/entities/providers/google-docs.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const platform = vi.hoisted(() => ({ OS: 'web' }));
+const fetchMock = vi.hoisted(() => vi.fn());
+const ingestionMocks = vi.hoisted(() => ({
+  ingestMarkdownContent: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({ Platform: platform }));
+vi.mock('../ingestion', () => ingestionMocks);
+
+import { ingestMarkdownContent } from '../ingestion';
+import {
+  buildGoogleDocsExportUrl,
+  fetchGoogleDocText,
+  GoogleDocsProvider,
+} from './google-docs';
+
+const mockedIngestMarkdownContent = vi.mocked(ingestMarkdownContent);
+
+describe('GoogleDocsProvider', () => {
+  beforeEach(() => {
+    platform.OS = 'web';
+    fetchMock.mockReset();
+    mockedIngestMarkdownContent.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches the exported document text through the browser CORS proxy', async () => {
+    fetchMock.mockResolvedValue(textResponse('# Moonlit Bazaar'));
+
+    await expect(fetchGoogleDocText('https://docs.google.com/document/d/doc_123/edit'))
+      .resolves.toBe('# Moonlit Bazaar');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://proxy.dndref.com/google-docs/document/d/doc_123/export?format=txt',
+    );
+  });
+
+  it('builds direct Google Docs export URLs for native callers', () => {
+    expect(buildGoogleDocsExportUrl(
+      'https://docs.google.com/document/d/doc_123/edit#heading=h.1',
+      null,
+    )).toBe('https://docs.google.com/document/d/doc_123/export?format=txt');
+    expect(buildGoogleDocsExportUrl('doc_123', null))
+      .toBe('https://docs.google.com/document/d/doc_123/export?format=txt');
+  });
+
+  it('loads fetched document text through shared ingestion', async () => {
+    const documentText = `
+## Moonlit Bazaar
+Type: place
+Aliases: Night Market
+
+Open only under the new moon.
+`;
+    const ingestedEntities = [{
+      id: 'moonlit-bazaar',
+      name: 'Moonlit Bazaar',
+      type: 'Location' as const,
+      aliases: ['Night Market'],
+      summary: 'Open only under the new moon.',
+    }];
+    fetchMock.mockResolvedValue(textResponse(documentText));
+    mockedIngestMarkdownContent.mockReturnValue(ingestedEntities);
+
+    const entities = await new GoogleDocsProvider('https://docs.google.com/document/d/doc_123/edit').load();
+
+    expect(mockedIngestMarkdownContent).toHaveBeenCalledOnce();
+    expect(mockedIngestMarkdownContent).toHaveBeenCalledWith(documentText);
+    expect(entities).toBe(ingestedEntities);
+  });
+
+  it('surfaces failed public document exports through the provider failure path', async () => {
+    fetchMock.mockResolvedValue(textResponse('', { ok: false, status: 403 }));
+
+    await expect(new GoogleDocsProvider('doc_123').load())
+      .rejects.toThrow('Google Docs fetch failed: 403');
+    expect(mockedIngestMarkdownContent).not.toHaveBeenCalled();
+  });
+
+  it('keeps browser CORS errors on the existing user-friendly path', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(fetchGoogleDocText('doc_123'))
+      .rejects.toThrow('Cannot reach Google Docs from the browser (CORS). Use the iOS app or paste content via file upload.');
+  });
+});
+
+function textResponse(
+  body: string,
+  init: { ok?: boolean; status?: number } = {},
+): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    text: vi.fn(async () => body),
+  } as unknown as Response;
+}

--- a/src/entities/providers/google-docs.ts
+++ b/src/entities/providers/google-docs.ts
@@ -6,10 +6,12 @@ import { ingestMarkdownContent } from '../ingestion';
 const GOOGLE_DOCS_ORIGIN = 'https://docs.google.com';
 const GOOGLE_DOCS_PROXY_PATH = '/google-docs';
 const GOOGLE_DOCS_SOURCE_NAME = 'Google Docs';
+const GOOGLE_DOCS_SHARE_HINT = 'Make sure the doc is shared with "Anyone with the link".';
+const GOOGLE_DOCS_CORS_FALLBACK = 'Use the iOS app or paste content via file upload.';
 
 export class GoogleDocsProvider implements WorldDataProvider {
-  readonly name = 'Google Docs';
-  private url: string;
+  readonly name = GOOGLE_DOCS_SOURCE_NAME;
+  private readonly url: string;
 
   constructor(url: string) {
     this.url = url;
@@ -23,25 +25,29 @@ export class GoogleDocsProvider implements WorldDataProvider {
   getName(): string { return this.name; }
 }
 
-export async function fetchGoogleDocText(url: string): Promise<string> {
-  const exportUrl = buildGoogleDocsExportUrl(url);
+export async function fetchGoogleDocText(urlOrId: string): Promise<string> {
+  const exportUrl = buildGoogleDocsExportUrl(urlOrId);
+
   try {
-    const res = await fetch(exportUrl);
-    if (!res.ok) throw new Error(`Google Docs fetch failed: ${res.status}. Make sure the doc is shared with "Anyone with the link".`);
-    return await res.text();
-  } catch (e) {
-    throw handleCorsError(e, GOOGLE_DOCS_SOURCE_NAME, 'Use the iOS app or paste content via file upload.');
+    const response = await fetch(exportUrl);
+    if (!response.ok) {
+      throw new Error(`Google Docs fetch failed: ${response.status}. ${GOOGLE_DOCS_SHARE_HINT}`);
+    }
+
+    return await response.text();
+  } catch (error) {
+    throw handleCorsError(error, GOOGLE_DOCS_SOURCE_NAME, GOOGLE_DOCS_CORS_FALLBACK);
   }
 }
 
-export function buildGoogleDocsExportUrl(url: string, corsProxy: string | null = CORS_PROXY): string {
-  const docId = extractGoogleDocId(url);
+export function buildGoogleDocsExportUrl(urlOrId: string, corsProxy: string | null = CORS_PROXY): string {
+  const docId = extractGoogleDocId(urlOrId);
   const baseUrl = corsProxy ? `${corsProxy}${GOOGLE_DOCS_PROXY_PATH}` : GOOGLE_DOCS_ORIGIN;
   return `${baseUrl}/document/d/${docId}/export?format=txt`;
 }
 
-export function extractGoogleDocId(url: string): string {
-  const match = url.match(/\/document\/d\/([a-zA-Z0-9_-]+)/);
+export function extractGoogleDocId(urlOrId: string): string {
+  const match = urlOrId.match(/\/document\/d\/([a-zA-Z0-9_-]+)/);
   if (match) return match[1];
-  return url.trim();
+  return urlOrId.trim();
 }

--- a/src/entities/providers/google-docs.ts
+++ b/src/entities/providers/google-docs.ts
@@ -1,9 +1,11 @@
-import { EntityIndex, WorldDataProvider } from '../index';
-import { MarkdownProvider } from './markdown';
 import { CORS_PROXY } from '../../proxy';
 import { handleCorsError } from '../../utils/providers';
+import { EntityIndex, WorldDataProvider } from '../index';
+import { ingestMarkdownContent } from '../ingestion';
 
-const GDOCS_BASE = CORS_PROXY ? `${CORS_PROXY}/google-docs` : 'https://docs.google.com';
+const GOOGLE_DOCS_ORIGIN = 'https://docs.google.com';
+const GOOGLE_DOCS_PROXY_PATH = '/google-docs';
+const GOOGLE_DOCS_SOURCE_NAME = 'Google Docs';
 
 export class GoogleDocsProvider implements WorldDataProvider {
   readonly name = 'Google Docs';
@@ -14,23 +16,31 @@ export class GoogleDocsProvider implements WorldDataProvider {
   }
 
   async load(): Promise<EntityIndex> {
-    const docId = extractDocId(this.url);
-    const exportUrl = `${GDOCS_BASE}/document/d/${docId}/export?format=txt`;
-    let text: string;
-    try {
-      const res = await fetch(exportUrl);
-      if (!res.ok) throw new Error(`Google Docs fetch failed: ${res.status}. Make sure the doc is shared with "Anyone with the link".`);
-      text = await res.text();
-    } catch (e) {
-      throw handleCorsError(e, 'Google Docs', 'Use the iOS app or paste content via file upload.');
-    }
-    return new MarkdownProvider(text, 'Google Docs').load();
+    const text = await fetchGoogleDocText(this.url);
+    return ingestMarkdownContent(text);
   }
 
   getName(): string { return this.name; }
 }
 
-function extractDocId(url: string): string {
+export async function fetchGoogleDocText(url: string): Promise<string> {
+  const exportUrl = buildGoogleDocsExportUrl(url);
+  try {
+    const res = await fetch(exportUrl);
+    if (!res.ok) throw new Error(`Google Docs fetch failed: ${res.status}. Make sure the doc is shared with "Anyone with the link".`);
+    return await res.text();
+  } catch (e) {
+    throw handleCorsError(e, GOOGLE_DOCS_SOURCE_NAME, 'Use the iOS app or paste content via file upload.');
+  }
+}
+
+export function buildGoogleDocsExportUrl(url: string, corsProxy: string | null = CORS_PROXY): string {
+  const docId = extractGoogleDocId(url);
+  const baseUrl = corsProxy ? `${corsProxy}${GOOGLE_DOCS_PROXY_PATH}` : GOOGLE_DOCS_ORIGIN;
+  return `${baseUrl}/document/d/${docId}/export?format=txt`;
+}
+
+export function extractGoogleDocId(url: string): string {
   const match = url.match(/\/document\/d\/([a-zA-Z0-9_-]+)/);
   if (match) return match[1];
   return url.trim();

--- a/src/entities/providers/markdown.ts
+++ b/src/entities/providers/markdown.ts
@@ -1,75 +1,5 @@
-import { Entity, EntityIndex, WorldDataProvider, normalizeEntityType, slugify } from '../index';
-
-interface MarkdownBlock {
-  name: string;
-  body: string;
-}
-
-function parseMarkdown(content: string): EntityIndex {
-  const blocks = getHeadingBlocks(content);
-  const sourceBlocks = blocks.length > 0 ? blocks : getFallbackBlock(content);
-
-  return sourceBlocks.map((block) => {
-    const name = cleanHeading(block.name);
-    if (!name) return null;
-
-    const id = slugify(name);
-    let type = normalizeEntityType('');
-    let aliases: string[] = [];
-    const summaryLines: string[] = [];
-
-    for (const line of block.body.split('\n')) {
-      const trimmed = line.trim();
-      if (trimmed === '---') continue;
-
-      const field = parseField(trimmed);
-      if (field?.key === 'type') {
-        type = normalizeEntityType(field.value);
-        continue;
-      }
-      if (field?.key === 'aliases') {
-        aliases = field.value.split(/[,;|]/).map((a) => a.trim()).filter(Boolean);
-        continue;
-      }
-
-      if (!trimmed && summaryLines.length === 0) continue;
-      summaryLines.push(line);
-    }
-
-    return { id, name, type, aliases, summary: summaryLines.join('\n').trim() };
-  }).filter((e): e is Entity => e !== null && e.name.length > 0);
-}
-
-function getHeadingBlocks(content: string): MarkdownBlock[] {
-  const headingRe = /^(#{1,3})\s+(.+?)\s*#*\s*$/gm;
-  const matches = Array.from(content.matchAll(headingRe));
-
-  return matches.map((match, i) => {
-    const start = (match.index ?? 0) + match[0].length;
-    const end = matches[i + 1]?.index ?? content.length;
-    return { name: match[2], body: content.slice(start, end) };
-  });
-}
-
-function getFallbackBlock(content: string): MarkdownBlock[] {
-  const lines = content.trim().split('\n');
-  const name = lines.shift()?.trim() ?? '';
-  return name ? [{ name, body: lines.join('\n') }] : [];
-}
-
-function cleanHeading(name: string): string {
-  return name.replace(/\*\*/g, '').trim();
-}
-
-function parseField(line: string): { key: string; value: string } | null {
-  const match = line.match(/^(?:[-*]\s*)?(?:\*\*)?([^:*]+):(?:\*\*)?\s*(.+)$/);
-  if (!match) return null;
-
-  return {
-    key: match[1].replace(/\*/g, '').trim().toLowerCase(),
-    value: match[2].trim(),
-  };
-}
+import { EntityIndex, WorldDataProvider } from '../index';
+import { ingestMarkdownContent } from '../ingestion';
 
 export class MarkdownProvider implements WorldDataProvider {
   private content: string;
@@ -81,7 +11,7 @@ export class MarkdownProvider implements WorldDataProvider {
   }
 
   async load(): Promise<EntityIndex> {
-    return parseMarkdown(this.content);
+    return ingestMarkdownContent(this.content);
   }
 
   getName(): string {

--- a/src/entities/providers/srd.ts
+++ b/src/entities/providers/srd.ts
@@ -1,6 +1,4 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-
-import { canPersistAppDataCache, createAppDataWriteToken, setAppDataItem } from '../../storage/app-data';
+import { createAppDataCacheSession, type AppDataCacheSession } from '../../storage/app-data';
 import { SRD_CACHE_KEY_PREFIX } from '../../storage/keys';
 import { fetchAll } from '../../utils/providers';
 import { Entity, EntityIndex, WorldDataProvider, slugify, stripHtml } from '../index';
@@ -52,9 +50,9 @@ export class SRDProvider implements WorldDataProvider {
 
   async load(): Promise<EntityIndex> {
     if (this.sources.length === 0) return [];
-    const cacheWriteToken = createAppDataWriteToken();
+    const cacheSession = createAppDataCacheSession();
     const cacheKey = `${SRD_CACHE_KEY_PREFIX}${[...this.sources].sort().join(',')}`;
-    const cached = await loadCache(cacheKey);
+    const cached = await loadCache(cacheKey, cacheSession);
     if (cached) return cached;
 
     const sourceParam = this.sources.join(',');
@@ -72,16 +70,16 @@ export class SRDProvider implements WorldDataProvider {
       ...monsters.map(monsterToEntity),
       ...items.map(itemToEntity),
     ];
-    await saveCache(cacheKey, entities, cacheWriteToken);
+    await saveCache(cacheKey, entities, cacheSession);
     return entities;
   }
 
   getName(): string { return this.name; }
 }
 
-async function loadCache(key: string): Promise<EntityIndex | null> {
+async function loadCache(key: string, cacheSession: AppDataCacheSession): Promise<EntityIndex | null> {
   try {
-    const raw = await AsyncStorage.getItem(key);
+    const raw = await cacheSession.getItem(key);
     if (!raw) return null;
     const cache = JSON.parse(raw) as { ts: number; entities: EntityIndex };
     if (Date.now() - cache.ts > CACHE_TTL_MS) return null;
@@ -91,10 +89,9 @@ async function loadCache(key: string): Promise<EntityIndex | null> {
   }
 }
 
-async function saveCache(key: string, entities: EntityIndex, token: number): Promise<void> {
-  if (!canPersistAppDataCache(token)) return;
+async function saveCache(key: string, entities: EntityIndex, cacheSession: AppDataCacheSession): Promise<void> {
   try {
-    await setAppDataItem(key, JSON.stringify({ ts: Date.now(), entities }), { cache: true, token });
+    await cacheSession.setItem(key, JSON.stringify({ ts: Date.now(), entities }));
   } catch {
     // Storage full -- skip caching
   }

--- a/src/entities/providers/srd.ts
+++ b/src/entities/providers/srd.ts
@@ -81,7 +81,7 @@ async function loadCache(key: string, cacheSession: AppDataCacheSession): Promis
   try {
     const raw = await cacheSession.getItem(key);
     if (!raw) return null;
-    const cache = JSON.parse(raw) as { ts: number; entities: EntityIndex };
+    const cache = JSON.parse(raw) as SRDCache;
     if (Date.now() - cache.ts > CACHE_TTL_MS) return null;
     return cache.entities;
   } catch {
@@ -90,8 +90,10 @@ async function loadCache(key: string, cacheSession: AppDataCacheSession): Promis
 }
 
 async function saveCache(key: string, entities: EntityIndex, cacheSession: AppDataCacheSession): Promise<void> {
+  const cache: SRDCache = { ts: Date.now(), entities };
+
   try {
-    await cacheSession.setItem(key, JSON.stringify({ ts: Date.now(), entities }));
+    await cacheSession.setItem(key, JSON.stringify(cache));
   } catch {
     // Storage full -- skip caching
   }

--- a/src/entity-card-presentation.test.ts
+++ b/src/entity-card-presentation.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'vitest';
+
+import type { CardState } from './context/session-types';
+import { deriveEntityCardPresentation, extractEntityCardSummaryBullets } from './entity-card-presentation';
+
+function makeCard(overrides: Partial<CardState> = {}): CardState {
+  return {
+    instanceId: 'card-1',
+    pinned: false,
+    entity: {
+      id: 'ironspire',
+      name: 'Ironspire Fortress',
+      type: 'Location',
+      aliases: [],
+      summary: 'Ancient dwarven stronghold. Seven levels deep.',
+      image: undefined,
+    },
+    ...overrides,
+  };
+}
+
+describe('extractEntityCardSummaryBullets', () => {
+  test('splits sentence summaries into display bullets with terminal marks removed', () => {
+    expect(extractEntityCardSummaryBullets('The Lich King. Undead sorcerer! His phylactery remains hidden.')).toEqual([
+      'The Lich King',
+      'Undead sorcerer',
+      'His phylactery remains hidden',
+    ]);
+  });
+
+  test.each(['', '   \n  '])('returns no bullets for empty summary %#', (summary) => {
+    expect(extractEntityCardSummaryBullets(summary)).toEqual([]);
+  });
+
+  test('limits long summaries to five bullets', () => {
+    const summary = 'One. Two. Three. Four. Five. Six. Seven.';
+
+    expect(extractEntityCardSummaryBullets(summary)).toEqual([
+      'One',
+      'Two',
+      'Three',
+      'Four',
+      'Five',
+    ]);
+  });
+
+  test('handles punctuation while preserving internal punctuation', () => {
+    const summary = 'Who guards the armory? Gorm knows: level 4. Wait--listen!';
+
+    expect(extractEntityCardSummaryBullets(summary)).toEqual([
+      'Who guards the armory',
+      'Gorm knows: level 4',
+      'Wait--listen',
+    ]);
+  });
+});
+
+describe('deriveEntityCardPresentation', () => {
+  test('represents type, accent color, image presence, and available actions for unpinned cards', () => {
+    const card = makeCard({
+      entity: {
+        id: 'ironspire',
+        name: 'Ironspire Fortress',
+        type: 'Location',
+        aliases: [],
+        summary: 'Ancient dwarven stronghold. Seven levels deep.',
+        image: 'https://example.com/ironspire.png',
+      },
+    });
+
+    expect(deriveEntityCardPresentation({ card, accentColor: '#2878b0' })).toEqual({
+      instanceId: 'card-1',
+      name: 'Ironspire Fortress',
+      type: 'Location',
+      typeLabel: 'LOCATION',
+      accentColor: '#2878b0',
+      pinned: false,
+      hasImage: true,
+      imageUri: 'https://example.com/ironspire.png',
+      bulletMarker: '>',
+      summaryBullets: ['Ancient dwarven stronghold', 'Seven levels deep'],
+      actions: {
+        pinToggle: {
+          kind: 'pin',
+          accessibilityLabel: 'Pin',
+          iconName: 'bookmark-outline',
+          available: true,
+        },
+        dismiss: {
+          kind: 'dismiss',
+          accessibilityLabel: 'Dismiss',
+          iconName: 'close',
+          available: true,
+        },
+      },
+    });
+  });
+
+  test('represents pinned state with unpin action and absent image state', () => {
+    const card = makeCard({
+      pinned: true,
+      entity: {
+        id: 'valdrath',
+        name: 'Valdrath the Undying',
+        type: 'NPC',
+        aliases: [],
+        summary: '',
+      },
+    });
+
+    expect(deriveEntityCardPresentation({ card, accentColor: '#45b882' })).toMatchObject({
+      name: 'Valdrath the Undying',
+      type: 'NPC',
+      typeLabel: 'NPC',
+      accentColor: '#45b882',
+      pinned: true,
+      hasImage: false,
+      imageUri: null,
+      summaryBullets: [],
+      actions: {
+        pinToggle: {
+          kind: 'unpin',
+          accessibilityLabel: 'Unpin',
+          iconName: 'bookmark',
+          available: true,
+        },
+        dismiss: {
+          kind: 'dismiss',
+          accessibilityLabel: 'Dismiss',
+          iconName: 'close',
+          available: true,
+        },
+      },
+    });
+  });
+});

--- a/src/entity-card-presentation.test.ts
+++ b/src/entity-card-presentation.test.ts
@@ -56,7 +56,7 @@ describe('extractEntityCardSummaryBullets', () => {
 });
 
 describe('deriveEntityCardPresentation', () => {
-  test('represents type, accent color, image presence, and available actions for unpinned cards', () => {
+  test('represents type, accent color, image, and actions for unpinned cards', () => {
     const card = makeCard({
       entity: {
         id: 'ironspire',
@@ -75,7 +75,6 @@ describe('deriveEntityCardPresentation', () => {
       typeLabel: 'LOCATION',
       accentColor: '#2878b0',
       pinned: false,
-      hasImage: true,
       imageUri: 'https://example.com/ironspire.png',
       bulletMarker: '>',
       summaryBullets: ['Ancient dwarven stronghold', 'Seven levels deep'],
@@ -84,13 +83,11 @@ describe('deriveEntityCardPresentation', () => {
           kind: 'pin',
           accessibilityLabel: 'Pin',
           iconName: 'bookmark-outline',
-          available: true,
         },
         dismiss: {
           kind: 'dismiss',
           accessibilityLabel: 'Dismiss',
           iconName: 'close',
-          available: true,
         },
       },
     });
@@ -105,30 +102,30 @@ describe('deriveEntityCardPresentation', () => {
         type: 'NPC',
         aliases: [],
         summary: '',
+        image: '',
       },
     });
 
-    expect(deriveEntityCardPresentation({ card, accentColor: '#45b882' })).toMatchObject({
+    expect(deriveEntityCardPresentation({ card, accentColor: '#45b882' })).toEqual({
+      instanceId: 'card-1',
       name: 'Valdrath the Undying',
       type: 'NPC',
       typeLabel: 'NPC',
       accentColor: '#45b882',
       pinned: true,
-      hasImage: false,
       imageUri: null,
+      bulletMarker: '>',
       summaryBullets: [],
       actions: {
         pinToggle: {
           kind: 'unpin',
           accessibilityLabel: 'Unpin',
           iconName: 'bookmark',
-          available: true,
         },
         dismiss: {
           kind: 'dismiss',
           accessibilityLabel: 'Dismiss',
           iconName: 'close',
-          available: true,
         },
       },
     });

--- a/src/entity-card-presentation.ts
+++ b/src/entity-card-presentation.ts
@@ -5,22 +5,19 @@ export const ENTITY_CARD_MAX_SUMMARY_BULLETS = 5;
 export const ENTITY_CARD_BULLET_MARKER = '>';
 
 type EntityCardPinToggleKind = 'pin' | 'unpin';
-type EntityCardActionIconName = 'bookmark' | 'bookmark-outline' | 'close';
-
+type EntityCardPinToggleIconName = 'bookmark' | 'bookmark-outline';
 type EntityCardPinToggleLabel = 'Pin' | 'Unpin';
 
 export interface EntityCardPinTogglePresentation {
   kind: EntityCardPinToggleKind;
   accessibilityLabel: EntityCardPinToggleLabel;
-  iconName: EntityCardActionIconName;
-  available: boolean;
+  iconName: EntityCardPinToggleIconName;
 }
 
 export interface EntityCardDismissActionPresentation {
   kind: 'dismiss';
   accessibilityLabel: 'Dismiss';
-  iconName: EntityCardActionIconName;
-  available: boolean;
+  iconName: 'close';
 }
 
 export interface EntityCardActionsPresentation {
@@ -35,7 +32,6 @@ export interface EntityCardPresentation {
   typeLabel: string;
   accentColor: string;
   pinned: boolean;
-  hasImage: boolean;
   imageUri: string | null;
   bulletMarker: typeof ENTITY_CARD_BULLET_MARKER;
   summaryBullets: string[];
@@ -55,6 +51,22 @@ export function extractEntityCardSummaryBullets(summary: string): string[] {
     .slice(0, ENTITY_CARD_MAX_SUMMARY_BULLETS);
 }
 
+function derivePinTogglePresentation(pinned: boolean): EntityCardPinTogglePresentation {
+  if (pinned) {
+    return {
+      kind: 'unpin',
+      accessibilityLabel: 'Unpin',
+      iconName: 'bookmark',
+    };
+  }
+
+  return {
+    kind: 'pin',
+    accessibilityLabel: 'Pin',
+    iconName: 'bookmark-outline',
+  };
+}
+
 export function deriveEntityCardPresentation({
   card,
   accentColor,
@@ -69,29 +81,15 @@ export function deriveEntityCardPresentation({
     typeLabel: entity.type.toUpperCase(),
     accentColor,
     pinned,
-    hasImage: imageUri !== null,
     imageUri,
     bulletMarker: ENTITY_CARD_BULLET_MARKER,
     summaryBullets: extractEntityCardSummaryBullets(entity.summary),
     actions: {
-      pinToggle: pinned
-        ? {
-            kind: 'unpin',
-            accessibilityLabel: 'Unpin',
-            iconName: 'bookmark',
-            available: true,
-          }
-        : {
-            kind: 'pin',
-            accessibilityLabel: 'Pin',
-            iconName: 'bookmark-outline',
-            available: true,
-          },
+      pinToggle: derivePinTogglePresentation(pinned),
       dismiss: {
         kind: 'dismiss',
         accessibilityLabel: 'Dismiss',
         iconName: 'close',
-        available: true,
       },
     },
   };

--- a/src/entity-card-presentation.ts
+++ b/src/entity-card-presentation.ts
@@ -1,0 +1,98 @@
+import type { CardState } from './context/session-types';
+import type { EntityType } from './entities';
+
+export const ENTITY_CARD_MAX_SUMMARY_BULLETS = 5;
+export const ENTITY_CARD_BULLET_MARKER = '>';
+
+type EntityCardPinToggleKind = 'pin' | 'unpin';
+type EntityCardActionIconName = 'bookmark' | 'bookmark-outline' | 'close';
+
+type EntityCardPinToggleLabel = 'Pin' | 'Unpin';
+
+export interface EntityCardPinTogglePresentation {
+  kind: EntityCardPinToggleKind;
+  accessibilityLabel: EntityCardPinToggleLabel;
+  iconName: EntityCardActionIconName;
+  available: boolean;
+}
+
+export interface EntityCardDismissActionPresentation {
+  kind: 'dismiss';
+  accessibilityLabel: 'Dismiss';
+  iconName: EntityCardActionIconName;
+  available: boolean;
+}
+
+export interface EntityCardActionsPresentation {
+  pinToggle: EntityCardPinTogglePresentation;
+  dismiss: EntityCardDismissActionPresentation;
+}
+
+export interface EntityCardPresentation {
+  instanceId: string;
+  name: string;
+  type: EntityType;
+  typeLabel: string;
+  accentColor: string;
+  pinned: boolean;
+  hasImage: boolean;
+  imageUri: string | null;
+  bulletMarker: typeof ENTITY_CARD_BULLET_MARKER;
+  summaryBullets: string[];
+  actions: EntityCardActionsPresentation;
+}
+
+export interface DeriveEntityCardPresentationInput {
+  card: CardState;
+  accentColor: string;
+}
+
+export function extractEntityCardSummaryBullets(summary: string): string[] {
+  return summary
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.replace(/[.!?]$/, '').trim())
+    .filter((sentence) => sentence.length > 0)
+    .slice(0, ENTITY_CARD_MAX_SUMMARY_BULLETS);
+}
+
+export function deriveEntityCardPresentation({
+  card,
+  accentColor,
+}: DeriveEntityCardPresentationInput): EntityCardPresentation {
+  const { entity, pinned } = card;
+  const imageUri = entity.image || null;
+
+  return {
+    instanceId: card.instanceId,
+    name: entity.name,
+    type: entity.type,
+    typeLabel: entity.type.toUpperCase(),
+    accentColor,
+    pinned,
+    hasImage: imageUri !== null,
+    imageUri,
+    bulletMarker: ENTITY_CARD_BULLET_MARKER,
+    summaryBullets: extractEntityCardSummaryBullets(entity.summary),
+    actions: {
+      pinToggle: pinned
+        ? {
+            kind: 'unpin',
+            accessibilityLabel: 'Unpin',
+            iconName: 'bookmark',
+            available: true,
+          }
+        : {
+            kind: 'pin',
+            accessibilityLabel: 'Pin',
+            iconName: 'bookmark-outline',
+            available: true,
+          },
+      dismiss: {
+        kind: 'dismiss',
+        accessibilityLabel: 'Dismiss',
+        iconName: 'close',
+        available: true,
+      },
+    },
+  };
+}

--- a/src/reference-card-layout.test.ts
+++ b/src/reference-card-layout.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  computeReferenceCardLayout,
+  type CardSize,
+} from './reference-card-layout';
+
+const cards = ['a', 'b', 'c', 'd', 'e'].map((instanceId) => ({ instanceId }));
+
+describe('computeReferenceCardLayout', () => {
+  test.each([
+    ['S', 3, 242.66666666666666],
+    ['M', 2, 369],
+    ['L', 2, 369],
+    ['XL', 1, 380],
+  ] satisfies Array<[CardSize, number, number]>)('uses %s portrait columns within the readable width', (cardSize, columns, cardWidth) => {
+    const layout = computeReferenceCardLayout({
+      cards,
+      measuredHeights: {},
+      viewport: { width: 768, height: 1024 },
+      cardSize,
+    });
+
+    expect(layout.columns).toBe(columns);
+    expect(layout.cardWidth).toBeCloseTo(cardWidth, 6);
+  });
+
+  test.each([
+    ['S', 4, 347.5],
+    ['M', 3, 380],
+    ['L', 2, 380],
+    ['XL', 2, 380],
+  ] satisfies Array<[CardSize, number, number]>)('uses %s landscape columns within the readable width', (cardSize, columns, cardWidth) => {
+    const layout = computeReferenceCardLayout({
+      cards,
+      measuredHeights: {},
+      viewport: { width: 1440, height: 900 },
+      cardSize,
+    });
+
+    expect(layout.columns).toBe(columns);
+    expect(layout.cardWidth).toBeCloseTo(cardWidth, 6);
+  });
+
+  test('centers constrained single-column XL portrait cards', () => {
+    const layout = computeReferenceCardLayout({
+      cards: cards.slice(0, 1),
+      measuredHeights: {},
+      viewport: { width: 768, height: 1024 },
+      cardSize: 'XL',
+    });
+
+    expect(layout.columns).toBe(1);
+    expect(layout.gridWidth).toBe(400);
+    expect(layout.xOffset).toBe(184);
+    expect(layout.positions.a).toEqual({ x: 189, y: 5 });
+  });
+
+  test('uses measured row heights for positions and content height', () => {
+    const layout = computeReferenceCardLayout({
+      cards,
+      measuredHeights: {
+        a: 160,
+        b: 240,
+        c: 180,
+        d: 320,
+        e: 150,
+      },
+      viewport: { width: 1440, height: 900 },
+      cardSize: 'M',
+    });
+
+    expect(layout.columns).toBe(3);
+    expect(layout.positions).toEqual({
+      a: { x: 135, y: 5 },
+      b: { x: 525, y: 5 },
+      c: { x: 915, y: 5 },
+      d: { x: 135, y: 245 },
+      e: { x: 525, y: 245 },
+    });
+    expect(layout.totalHeight).toBe(570);
+  });
+
+  test('falls back to the default card height until rows are measured', () => {
+    const layout = computeReferenceCardLayout({
+      cards: cards.slice(0, 4),
+      measuredHeights: { a: 220 },
+      viewport: { width: 1440, height: 900 },
+      cardSize: 'M',
+    });
+
+    expect(layout.positions.d).toEqual({ x: 135, y: 225 });
+    expect(layout.totalHeight).toBe(430);
+  });
+});

--- a/src/reference-card-layout.ts
+++ b/src/reference-card-layout.ts
@@ -1,0 +1,99 @@
+export type CardSize = 'S' | 'M' | 'L' | 'XL';
+
+export interface CardSizeLayoutConfig {
+  landscapeCols: number;
+  portraitCols: number;
+}
+
+export const CARD_SIZE_LAYOUT_CONFIGS: Record<CardSize, CardSizeLayoutConfig> = {
+  S:  { landscapeCols: 4, portraitCols: 3 },
+  M:  { landscapeCols: 3, portraitCols: 2 },
+  L:  { landscapeCols: 2, portraitCols: 2 },
+  XL: { landscapeCols: 2, portraitCols: 1 },
+};
+
+export const REFERENCE_CARD_LAYOUT = {
+  gridPad: 5,
+  cardMargin: 5,
+  minCardWidth: 230,
+  maxCardWidth: 380,
+  defaultMeasuredHeight: 200,
+} as const;
+
+export interface ReferenceCardLayoutItem {
+  instanceId: string;
+}
+
+export interface ReferenceCardLayoutViewport {
+  width: number;
+  height: number;
+}
+
+export interface ReferenceCardPosition {
+  x: number;
+  y: number;
+}
+
+export interface ReferenceCardLayout {
+  columns: number;
+  cardWidth: number;
+  gridWidth: number;
+  xOffset: number;
+  positions: Record<string, ReferenceCardPosition>;
+  totalHeight: number;
+}
+
+export interface ComputeReferenceCardLayoutInput {
+  cards: readonly ReferenceCardLayoutItem[];
+  measuredHeights: Readonly<Record<string, number>>;
+  viewport: ReferenceCardLayoutViewport;
+  cardSize: CardSize;
+}
+
+export function computeReferenceCardLayout({
+  cards,
+  measuredHeights,
+  viewport,
+  cardSize,
+}: ComputeReferenceCardLayoutInput): ReferenceCardLayout {
+  const { gridPad, cardMargin, minCardWidth, maxCardWidth, defaultMeasuredHeight } = REFERENCE_CARD_LAYOUT;
+  const config = CARD_SIZE_LAYOUT_CONFIGS[cardSize];
+  const preferredColumns = viewport.width > viewport.height ? config.landscapeCols : config.portraitCols;
+  const readableColumns = Math.max(1, Math.floor((viewport.width - 2 * gridPad) / (minCardWidth + 2 * cardMargin)));
+  const columns = Math.min(preferredColumns, readableColumns);
+  const gridWidth = Math.min(viewport.width, columns * (maxCardWidth + 2 * cardMargin) + 2 * gridPad);
+  const xOffset = Math.max(0, (viewport.width - gridWidth) / 2);
+  const cardWidth = (gridWidth - 2 * gridPad) / columns - 2 * cardMargin;
+  const colWidth = cardWidth + 2 * cardMargin;
+
+  const rowHeights: number[] = [];
+  for (let i = 0; i < cards.length; i++) {
+    const row = Math.floor(i / columns);
+    const h = measuredHeights[cards[i].instanceId] ?? defaultMeasuredHeight;
+    rowHeights[row] = Math.max(rowHeights[row] ?? 0, h);
+  }
+
+  const rowY: number[] = [gridPad];
+  for (let r = 0; r < rowHeights.length; r++) {
+    rowY[r + 1] = rowY[r] + rowHeights[r];
+  }
+
+  const positions: Record<string, ReferenceCardPosition> = {};
+  for (let i = 0; i < cards.length; i++) {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    positions[cards[i].instanceId] = {
+      x: xOffset + gridPad + col * colWidth,
+      y: rowY[row],
+    };
+  }
+
+  return {
+    columns,
+    cardWidth,
+    gridWidth,
+    xOffset,
+    positions,
+    totalHeight: rowY[rowHeights.length] + gridPad,
+  };
+}

--- a/src/reference-card-layout.ts
+++ b/src/reference-card-layout.ts
@@ -1,4 +1,10 @@
-export type CardSize = 'S' | 'M' | 'L' | 'XL';
+export const CARD_SIZES = ['S', 'M', 'L', 'XL'] as const;
+
+export type CardSize = (typeof CARD_SIZES)[number];
+
+export function isCardSize(value: unknown): value is CardSize {
+  return typeof value === 'string' && (CARD_SIZES as readonly string[]).includes(value);
+}
 
 export interface CardSizeLayoutConfig {
   landscapeCols: number;
@@ -56,26 +62,39 @@ export function computeReferenceCardLayout({
   viewport,
   cardSize,
 }: ComputeReferenceCardLayoutInput): ReferenceCardLayout {
-  const { gridPad, cardMargin, minCardWidth, maxCardWidth, defaultMeasuredHeight } = REFERENCE_CARD_LAYOUT;
+  const {
+    gridPad,
+    cardMargin,
+    minCardWidth,
+    maxCardWidth,
+    defaultMeasuredHeight,
+  } = REFERENCE_CARD_LAYOUT;
+  const { width: viewportWidth, height: viewportHeight } = viewport;
   const config = CARD_SIZE_LAYOUT_CONFIGS[cardSize];
-  const preferredColumns = viewport.width > viewport.height ? config.landscapeCols : config.portraitCols;
-  const readableColumns = Math.max(1, Math.floor((viewport.width - 2 * gridPad) / (minCardWidth + 2 * cardMargin)));
-  const columns = Math.min(preferredColumns, readableColumns);
-  const gridWidth = Math.min(viewport.width, columns * (maxCardWidth + 2 * cardMargin) + 2 * gridPad);
-  const xOffset = Math.max(0, (viewport.width - gridWidth) / 2);
+  const preferredColumns = viewportWidth > viewportHeight ? config.landscapeCols : config.portraitCols;
+  const maxReadableColumns = Math.max(
+    1,
+    Math.floor((viewportWidth - 2 * gridPad) / (minCardWidth + 2 * cardMargin)),
+  );
+  const columns = Math.min(preferredColumns, maxReadableColumns);
+  const gridWidth = Math.min(
+    viewportWidth,
+    columns * (maxCardWidth + 2 * cardMargin) + 2 * gridPad,
+  );
+  const xOffset = Math.max(0, (viewportWidth - gridWidth) / 2);
   const cardWidth = (gridWidth - 2 * gridPad) / columns - 2 * cardMargin;
-  const colWidth = cardWidth + 2 * cardMargin;
+  const columnWidth = cardWidth + 2 * cardMargin;
 
   const rowHeights: number[] = [];
   for (let i = 0; i < cards.length; i++) {
     const row = Math.floor(i / columns);
-    const h = measuredHeights[cards[i].instanceId] ?? defaultMeasuredHeight;
-    rowHeights[row] = Math.max(rowHeights[row] ?? 0, h);
+    const cardHeight = measuredHeights[cards[i].instanceId] ?? defaultMeasuredHeight;
+    rowHeights[row] = Math.max(rowHeights[row] ?? 0, cardHeight);
   }
 
-  const rowY: number[] = [gridPad];
+  const rowTops: number[] = [gridPad];
   for (let r = 0; r < rowHeights.length; r++) {
-    rowY[r + 1] = rowY[r] + rowHeights[r];
+    rowTops[r + 1] = rowTops[r] + rowHeights[r];
   }
 
   const positions: Record<string, ReferenceCardPosition> = {};
@@ -83,8 +102,8 @@ export function computeReferenceCardLayout({
     const col = i % columns;
     const row = Math.floor(i / columns);
     positions[cards[i].instanceId] = {
-      x: xOffset + gridPad + col * colWidth,
-      y: rowY[row],
+      x: xOffset + gridPad + col * columnWidth,
+      y: rowTops[row],
     };
   }
 
@@ -94,6 +113,6 @@ export function computeReferenceCardLayout({
     gridWidth,
     xOffset,
     positions,
-    totalHeight: rowY[rowHeights.length] + gridPad,
+    totalHeight: rowTops[rowHeights.length] + gridPad,
   };
 }

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -1,5 +1,5 @@
 import type { IoniconName } from '../components/Ionicon';
-import { CardSize, ColorScheme } from '../context/ui-settings';
+import type { CardSize, ColorScheme } from '../context/ui-settings';
 
 export type Category = 'display' | 'voice' | 'data' | 'files' | 'ai';
 

--- a/src/settings/files-settings-category.test.ts
+++ b/src/settings/files-settings-category.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', () => ({
+  Alert: { alert: vi.fn() },
+  Platform: { OS: 'web' },
+}));
+
+import {
+  createFilesSettingsCategoryController,
+  type FilesSettingsCategoryController,
+  type FilesSettingsCategoryControllerOptions,
+} from './files-settings-category';
+import type { UploadedFile } from '../entities/providers/file-upload';
+
+const controllers: FilesSettingsCategoryController[] = [];
+
+function makeUpload(id: string, name: string, content = `# ${name}`): UploadedFile {
+  return { id, name, content };
+}
+
+function createController(options: FilesSettingsCategoryControllerOptions) {
+  const controller = createFilesSettingsCategoryController(options);
+  controllers.push(controller);
+  return controller;
+}
+
+describe('files settings category controller', () => {
+  afterEach(() => {
+    controllers.splice(0).forEach((controller) => controller.dispose());
+  });
+
+  it('stores pasted content, refreshes uploads, and bumps the uploads version', async () => {
+    const events: string[] = [];
+    let uploads: UploadedFile[] = [];
+    const addUpload = vi.fn(async (name: string, content: string) => {
+      events.push(`add:${name}:${content}`);
+      uploads = [...uploads, makeUpload('pasted', name, content)];
+    });
+    const getUploads = vi.fn(async () => {
+      events.push('get');
+      return uploads;
+    });
+    const bumpUploads = vi.fn(() => events.push('bump'));
+    const controller = createController({ addUpload, getUploads, bumpUploads });
+
+    controller.setPasteFileName(' villains.md ');
+    controller.setPasteContent('# Lord Ember');
+    await controller.addPastedContent();
+
+    expect(addUpload).toHaveBeenCalledWith('villains.md', '# Lord Ember');
+    expect(events).toEqual(['add:villains.md:# Lord Ember', 'get', 'bump']);
+    expect(controller.getSnapshot()).toMatchObject({
+      uploads: [makeUpload('pasted', 'villains.md', '# Lord Ember')],
+      pasteFileName: '',
+      pasteContent: '',
+    });
+  });
+
+  it('chooses web files through the picker and stores every selected file', async () => {
+    let uploads: UploadedFile[] = [];
+    const addUpload = vi.fn(async (name: string, content: string) => {
+      uploads = [...uploads, makeUpload(name, name, content)];
+    });
+    const getUploads = vi.fn(async () => uploads);
+    const bumpUploads = vi.fn();
+    const controller = createController({
+      addUpload,
+      getUploads,
+      bumpUploads,
+      pickFiles: vi.fn(async () => [
+        { name: 'npc.md', text: async () => '# NPC' },
+        { name: 'items.json', text: async () => '[{"name":"Moonblade"}]' },
+      ]),
+    });
+
+    await controller.pickFilesWeb();
+
+    expect(addUpload).toHaveBeenNthCalledWith(1, 'npc.md', '# NPC');
+    expect(addUpload).toHaveBeenNthCalledWith(2, 'items.json', '[{"name":"Moonblade"}]');
+    expect(controller.getSnapshot().uploads.map((upload) => upload.name)).toEqual(['npc.md', 'items.json']);
+    expect(bumpUploads).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes an upload with pending row state and refreshes the session upload version', async () => {
+    let uploads = [makeUpload('keep', 'keep.md'), makeUpload('drop', 'drop.md')];
+    const bumpUploads = vi.fn();
+    const controller = createController({
+      getUploads: vi.fn(async () => uploads),
+      removeUpload: vi.fn(async (id: string) => {
+        uploads = uploads.filter((upload) => upload.id !== id);
+      }),
+      bumpUploads,
+    });
+
+    await controller.load();
+    bumpUploads.mockClear();
+    const deleteUpload = controller.deleteUpload('drop');
+
+    expect(controller.getSnapshot().removingUploadId).toBe('drop');
+    await deleteUpload;
+    expect(controller.getSnapshot().uploads.map((upload) => upload.id)).toEqual(['keep']);
+    expect(controller.getSnapshot().removingUploadId).toBeNull();
+    expect(bumpUploads).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes all local app data through the files category reset path', async () => {
+    const events: string[] = [];
+    let finishReset!: () => void;
+    const controller = createController({
+      confirmDeleteAllData: vi.fn(async () => {
+        events.push('confirm');
+        return true;
+      }),
+      getUploads: vi.fn(async () => [makeUpload('old', 'old.md')]),
+      resetStoredAppData: vi.fn(() => new Promise<void>((resolve) => {
+        events.push('reset-storage');
+        finishReset = resolve;
+      })),
+      stopSession: vi.fn(() => events.push('stop-session')),
+      onDeleteAllDataReset: vi.fn(() => events.push('reset-settings')),
+    });
+    await controller.load();
+    controller.setPasteFileName('scratch.md');
+    controller.setPasteContent('# Scratch');
+
+    const deletion = controller.deleteAllData();
+    await Promise.resolve();
+
+    expect(controller.getSnapshot().deleteAllPending).toBe(true);
+    finishReset();
+    await deletion;
+
+    expect(events).toEqual(['confirm', 'stop-session', 'reset-storage', 'reset-settings']);
+    expect(controller.getSnapshot()).toMatchObject({
+      uploads: [],
+      pasteFileName: '',
+      pasteContent: '',
+      deleteAllPending: false,
+      deleteAllStatus: 'All local app data was deleted.',
+    });
+  });
+});

--- a/src/settings/files-settings-category.ts
+++ b/src/settings/files-settings-category.ts
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { Alert, Platform } from 'react-native';
+
+import {
+  addUpload as addStoredUpload,
+  getUploads as getStoredUploads,
+  removeUpload as removeStoredUpload,
+  type UploadedFile,
+} from '../entities/providers/file-upload';
+import { resetStoredAppData as resetStoredLocalAppData } from '../storage/app-data';
+
+const DELETE_ALL_MESSAGE = 'This deletes uploads, pasted content, AI parsed files, saved settings, API keys, source URLs, cached SRD data, and the current session on this device.';
+const PASTED_CONTENT_FILE_NAME = 'Pasted Content.md';
+
+type FilesSettingsListener = (snapshot: FilesSettingsCategorySnapshot) => void;
+type MaybePromise<T> = T | Promise<T>;
+
+export interface PickedTextFile {
+  name: string;
+  text: () => Promise<string>;
+}
+
+export interface FilesSettingsCategorySnapshot {
+  uploads: UploadedFile[];
+  removingUploadId: string | null;
+  pasteFileName: string;
+  pasteContent: string;
+  deleteAllPending: boolean;
+  deleteAllStatus: string;
+}
+
+export interface FilesSettingsCategoryControllerOptions {
+  getUploads?: () => Promise<UploadedFile[]>;
+  addUpload?: (name: string, content: string) => MaybePromise<void>;
+  removeUpload?: (id: string) => MaybePromise<void>;
+  bumpUploads?: () => void;
+  pickFiles?: () => Promise<PickedTextFile[]>;
+  confirmDeleteAllData?: () => Promise<boolean>;
+  resetStoredAppData?: () => Promise<unknown>;
+  stopSession?: () => void;
+  onDeleteAllDataReset?: () => void;
+}
+
+export interface FilesSettingsCategoryController {
+  getSnapshot(): FilesSettingsCategorySnapshot;
+  subscribe(listener: FilesSettingsListener): () => void;
+  load(): Promise<void>;
+  setPasteFileName(update: SetStateAction<string>): void;
+  setPasteContent(update: SetStateAction<string>): void;
+  saveUpload(name: string, content: string): Promise<void>;
+  pickFilesWeb(): Promise<void>;
+  addPastedContent(): Promise<void>;
+  deleteUpload(id: string): Promise<void>;
+  deleteAllData(): Promise<void>;
+  reset(): void;
+  dispose(): void;
+}
+
+class DefaultFilesSettingsCategoryController implements FilesSettingsCategoryController {
+  private readonly getUploads: () => Promise<UploadedFile[]>;
+  private readonly addUpload: (name: string, content: string) => MaybePromise<void>;
+  private readonly removeUpload: (id: string) => MaybePromise<void>;
+  private readonly bumpUploads: () => void;
+  private readonly pickFiles: () => Promise<PickedTextFile[]>;
+  private readonly confirmDeleteAllData: () => Promise<boolean>;
+  private readonly resetStoredAppData: () => Promise<unknown>;
+  private readonly stopSession: () => void;
+  private readonly onDeleteAllDataReset: () => void;
+  private readonly listeners = new Set<FilesSettingsListener>();
+  private snapshot: FilesSettingsCategorySnapshot = createDefaultSnapshot();
+  private refreshGeneration = 0;
+  private disposed = false;
+
+  constructor(options: FilesSettingsCategoryControllerOptions = {}) {
+    this.getUploads = options.getUploads ?? getStoredUploads;
+    this.addUpload = options.addUpload ?? addStoredUpload;
+    this.removeUpload = options.removeUpload ?? removeStoredUpload;
+    this.bumpUploads = options.bumpUploads ?? noop;
+    this.pickFiles = options.pickFiles ?? pickFilesWithWebInput;
+    this.confirmDeleteAllData = options.confirmDeleteAllData ?? confirmDeleteAllData;
+    this.resetStoredAppData = options.resetStoredAppData ?? resetStoredLocalAppData;
+    this.stopSession = options.stopSession ?? noop;
+    this.onDeleteAllDataReset = options.onDeleteAllDataReset ?? noop;
+  }
+
+  getSnapshot(): FilesSettingsCategorySnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(listener: FilesSettingsListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async load(): Promise<void> {
+    await this.refreshUploads(true);
+  }
+
+  setPasteFileName(update: SetStateAction<string>): void {
+    this.updateSnapshot({ pasteFileName: resolveStringUpdate(update, this.snapshot.pasteFileName) });
+  }
+
+  setPasteContent(update: SetStateAction<string>): void {
+    this.updateSnapshot({ pasteContent: resolveStringUpdate(update, this.snapshot.pasteContent) });
+  }
+
+  async saveUpload(name: string, content: string): Promise<void> {
+    await this.addUpload(name, content);
+    await this.refreshUploads(true);
+  }
+
+  async pickFilesWeb(): Promise<void> {
+    const files = await this.pickFiles();
+    await Promise.all(files.map(async (file) => {
+      await this.addUpload(file.name, await file.text());
+    }));
+    await this.refreshUploads(true);
+  }
+
+  async addPastedContent(): Promise<void> {
+    const content = this.snapshot.pasteContent;
+    if (!content.trim()) return;
+
+    const name = this.snapshot.pasteFileName.trim() || PASTED_CONTENT_FILE_NAME;
+    await this.addUpload(name, content);
+    this.updateSnapshot({ pasteFileName: '', pasteContent: '' });
+    await this.refreshUploads(true);
+  }
+
+  async deleteUpload(id: string): Promise<void> {
+    this.updateSnapshot({ removingUploadId: id });
+    try {
+      await this.removeUpload(id);
+      await this.refreshUploads(true);
+    } finally {
+      if (!this.disposed && this.snapshot.removingUploadId === id) {
+        this.updateSnapshot({ removingUploadId: null });
+      }
+    }
+  }
+
+  async deleteAllData(): Promise<void> {
+    const confirmed = await this.confirmDeleteAllData();
+    if (this.disposed || !confirmed) return;
+
+    this.updateSnapshot({ deleteAllPending: true, deleteAllStatus: '' });
+    try {
+      this.stopSession();
+      await this.resetStoredAppData();
+      if (this.disposed) return;
+
+      this.onDeleteAllDataReset();
+      this.refreshGeneration += 1;
+      this.updateSnapshot({
+        uploads: [],
+        removingUploadId: null,
+        pasteFileName: '',
+        pasteContent: '',
+        deleteAllStatus: 'All local app data was deleted.',
+      });
+    } catch (e: unknown) {
+      if (!this.disposed) {
+        this.updateSnapshot({ deleteAllStatus: `Delete failed: ${e instanceof Error ? e.message : String(e)}` });
+      }
+    } finally {
+      if (!this.disposed) this.updateSnapshot({ deleteAllPending: false });
+    }
+  }
+
+  reset(): void {
+    this.refreshGeneration += 1;
+    this.replaceSnapshot(createDefaultSnapshot());
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.refreshGeneration += 1;
+    this.listeners.clear();
+  }
+
+  private async refreshUploads(shouldBumpUploads: boolean): Promise<void> {
+    const generation = ++this.refreshGeneration;
+    const uploads = await this.getUploads();
+    if (this.disposed || generation !== this.refreshGeneration) return;
+
+    this.updateSnapshot({ uploads });
+    if (shouldBumpUploads) this.bumpUploads();
+  }
+
+  private updateSnapshot(patch: Partial<FilesSettingsCategorySnapshot>): void {
+    this.replaceSnapshot({ ...this.snapshot, ...patch });
+  }
+
+  private replaceSnapshot(snapshot: FilesSettingsCategorySnapshot): void {
+    this.snapshot = snapshot;
+    this.listeners.forEach((listener) => listener(this.snapshot));
+  }
+}
+
+function createDefaultSnapshot(): FilesSettingsCategorySnapshot {
+  return {
+    uploads: [],
+    removingUploadId: null,
+    pasteFileName: '',
+    pasteContent: '',
+    deleteAllPending: false,
+    deleteAllStatus: '',
+  };
+}
+
+function noop(): void {}
+
+function resolveStringUpdate(update: SetStateAction<string>, current: string): string {
+  return typeof update === 'function' ? update(current) : update;
+}
+
+function pickFilesWithWebInput(): Promise<PickedTextFile[]> {
+  if (Platform.OS !== 'web' || typeof document === 'undefined') return Promise.resolve([]);
+
+  return new Promise((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.multiple = true;
+    input.accept = '.md,.txt,.json';
+    input.onchange = () => {
+      const files = Array.from(input.files ?? []) as PickedTextFile[];
+      input.onchange = null;
+      resolve(files);
+    };
+    input.click();
+  });
+}
+
+function confirmDeleteAllData(): Promise<boolean> {
+  if (Platform.OS === 'web' && typeof window !== 'undefined') {
+    return Promise.resolve(window.confirm(`Delete all local app data?\n\n${DELETE_ALL_MESSAGE}`));
+  }
+
+  return new Promise((resolve) => {
+    Alert.alert(
+      'Delete all local app data?',
+      DELETE_ALL_MESSAGE,
+      [
+        { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+        { text: 'Delete All Data', style: 'destructive', onPress: () => resolve(true) },
+      ],
+      { cancelable: true, onDismiss: () => resolve(false) },
+    );
+  });
+}
+
+export function createFilesSettingsCategoryController(
+  options: FilesSettingsCategoryControllerOptions = {},
+): FilesSettingsCategoryController {
+  return new DefaultFilesSettingsCategoryController(options);
+}
+
+export function useFilesSettingsCategory(options: FilesSettingsCategoryControllerOptions) {
+  const controllerRef = useRef<FilesSettingsCategoryController | null>(null);
+  if (!controllerRef.current) {
+    controllerRef.current = createFilesSettingsCategoryController(options);
+  }
+  const controller = controllerRef.current;
+  const [snapshot, setSnapshot] = useState(() => controller.getSnapshot());
+
+  useEffect(() => controller.subscribe(setSnapshot), [controller]);
+
+  useEffect(() => {
+    void controller.load();
+    return () => controller.dispose();
+  }, [controller]);
+
+  const setPasteFileName = useCallback<Dispatch<SetStateAction<string>>>((update) => {
+    controller.setPasteFileName(update);
+  }, [controller]);
+  const setPasteContent = useCallback<Dispatch<SetStateAction<string>>>((update) => {
+    controller.setPasteContent(update);
+  }, [controller]);
+
+  return {
+    uploads: snapshot.uploads,
+    removingUploadId: snapshot.removingUploadId,
+    pasteFileName: snapshot.pasteFileName,
+    setPasteFileName,
+    pasteContent: snapshot.pasteContent,
+    setPasteContent,
+    pickFilesWeb: useCallback(() => controller.pickFilesWeb(), [controller]),
+    handlePasteAdd: useCallback(() => controller.addPastedContent(), [controller]),
+    handleDeleteUpload: useCallback((id: string) => controller.deleteUpload(id), [controller]),
+    handleDeleteAllData: useCallback(() => controller.deleteAllData(), [controller]),
+    saveUpload: useCallback((name: string, content: string) => controller.saveUpload(name, content), [controller]),
+    deleteAllPending: snapshot.deleteAllPending,
+    deleteAllStatus: snapshot.deleteAllStatus,
+  };
+}

--- a/src/settings/files-settings-category.ts
+++ b/src/settings/files-settings-category.ts
@@ -95,7 +95,7 @@ class DefaultFilesSettingsCategoryController implements FilesSettingsCategoryCon
   }
 
   async load(): Promise<void> {
-    await this.refreshUploads(true);
+    await this.refreshUploads();
   }
 
   setPasteFileName(update: SetStateAction<string>): void {
@@ -108,7 +108,7 @@ class DefaultFilesSettingsCategoryController implements FilesSettingsCategoryCon
 
   async saveUpload(name: string, content: string): Promise<void> {
     await this.addUpload(name, content);
-    await this.refreshUploads(true);
+    await this.refreshUploads();
   }
 
   async pickFilesWeb(): Promise<void> {
@@ -116,7 +116,7 @@ class DefaultFilesSettingsCategoryController implements FilesSettingsCategoryCon
     await Promise.all(files.map(async (file) => {
       await this.addUpload(file.name, await file.text());
     }));
-    await this.refreshUploads(true);
+    await this.refreshUploads();
   }
 
   async addPastedContent(): Promise<void> {
@@ -126,14 +126,14 @@ class DefaultFilesSettingsCategoryController implements FilesSettingsCategoryCon
     const name = this.snapshot.pasteFileName.trim() || PASTED_CONTENT_FILE_NAME;
     await this.addUpload(name, content);
     this.updateSnapshot({ pasteFileName: '', pasteContent: '' });
-    await this.refreshUploads(true);
+    await this.refreshUploads();
   }
 
   async deleteUpload(id: string): Promise<void> {
     this.updateSnapshot({ removingUploadId: id });
     try {
       await this.removeUpload(id);
-      await this.refreshUploads(true);
+      await this.refreshUploads();
     } finally {
       if (!this.disposed && this.snapshot.removingUploadId === id) {
         this.updateSnapshot({ removingUploadId: null });
@@ -180,13 +180,13 @@ class DefaultFilesSettingsCategoryController implements FilesSettingsCategoryCon
     this.listeners.clear();
   }
 
-  private async refreshUploads(shouldBumpUploads: boolean): Promise<void> {
+  private async refreshUploads(): Promise<void> {
     const generation = ++this.refreshGeneration;
     const uploads = await this.getUploads();
     if (this.disposed || generation !== this.refreshGeneration) return;
 
     this.updateSnapshot({ uploads });
-    if (shouldBumpUploads) this.bumpUploads();
+    this.bumpUploads();
   }
 
   private updateSnapshot(patch: Partial<FilesSettingsCategorySnapshot>): void {
@@ -225,7 +225,9 @@ function pickFilesWithWebInput(): Promise<PickedTextFile[]> {
     input.multiple = true;
     input.accept = '.md,.txt,.json';
     input.onchange = () => {
-      const files = Array.from(input.files ?? []) as PickedTextFile[];
+      const files = Array.from(input.files ?? [], (file) => ({
+        name: file.name, text: () => file.text(),
+      }));
       input.onchange = null;
       resolve(files);
     };

--- a/src/settings/renderers/DisplaySection.tsx
+++ b/src/settings/renderers/DisplaySection.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 
-import { CardSize, ColorScheme } from '../../context/ui-settings';
+import { CARD_SIZES, COLOR_SCHEMES } from '../../context/ui-settings';
 import { CARD_SIZE_DESCS, CARD_SIZE_LABELS, COLOR_SCHEME_LABELS } from '../constants';
 import { DisplaySectionProps } from '../types';
 
 export function DisplaySection({ cardSize, setCardSize, colorScheme, setColorScheme, styles }: DisplaySectionProps) {
-  const CARD_SIZE_CONFIGS = { S: {}, M: {}, L: {}, XL: {} };
-
   return (
     <View testID="settings-content" style={styles.contentInner}>
       <View style={styles.group}>
         <Text style={styles.groupLabel}>CARD SIZE</Text>
         <View style={styles.segmentRow}>
-          {(Object.keys(CARD_SIZE_CONFIGS) as CardSize[]).map((size) => (
+          {CARD_SIZES.map((size) => (
             <TouchableOpacity
               key={size}
               style={[styles.segment, cardSize === size && styles.segmentActive]}
@@ -35,7 +33,7 @@ export function DisplaySection({ cardSize, setCardSize, colorScheme, setColorSch
       <View style={styles.group}>
         <Text style={styles.groupLabel}>THEME</Text>
         <View style={styles.segmentRow}>
-          {(['system', 'dark', 'light'] as ColorScheme[]).map((scheme) => (
+          {COLOR_SCHEMES.map((scheme) => (
             <TouchableOpacity
               key={scheme}
               style={[styles.segment, colorScheme === scheme && styles.segmentActive]}

--- a/src/settings/renderers/VoiceSection.tsx
+++ b/src/settings/renderers/VoiceSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 import { KeyLink } from '../KeyLink';
 import { VoiceSectionProps } from '../types';

--- a/src/settings/voice-settings-category.test.ts
+++ b/src/settings/voice-settings-category.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', () => ({ Platform: { OS: 'web' } }));
+
+import { DEFAULT_STT_SETTINGS, type STTSettings } from '../stt';
+import {
+  VOICE_SAVED_INDICATOR_MS,
+  createVoiceSettingsCategoryController,
+} from './voice-settings-category';
+
+describe('voice settings category controller', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('loads saved voice settings and saves the current category draft', async () => {
+    const savedSettings: STTSettings = {
+      provider: 'deepgram',
+      deepgramApiKey: 'saved-deepgram-key',
+    };
+    const loadVoiceSettings = vi.fn(async () => savedSettings);
+    const saveVoiceSettings = vi.fn(async () => true);
+    const controller = createVoiceSettingsCategoryController({
+      loadVoiceSettings,
+      saveVoiceSettings,
+    });
+
+    await controller.load();
+    expect(controller.getSnapshot().sttSettings).toEqual(savedSettings);
+
+    controller.setSttSettings((current) => ({
+      ...current,
+      provider: 'web-speech',
+    }));
+    await controller.save();
+
+    expect(saveVoiceSettings).toHaveBeenCalledWith({
+      provider: 'web-speech',
+      deepgramApiKey: 'saved-deepgram-key',
+    });
+    expect(controller.getSnapshot().voiceSaved).toBe(true);
+  });
+
+  it('hides the saved indicator after the confirmation timeout', async () => {
+    vi.useFakeTimers();
+    const controller = createVoiceSettingsCategoryController({
+      loadVoiceSettings: vi.fn(async () => DEFAULT_STT_SETTINGS),
+      saveVoiceSettings: vi.fn(async () => true),
+    });
+
+    await controller.save();
+    expect(controller.getSnapshot().voiceSaved).toBe(true);
+
+    vi.advanceTimersByTime(VOICE_SAVED_INDICATOR_MS - 1);
+    expect(controller.getSnapshot().voiceSaved).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(controller.getSnapshot().voiceSaved).toBe(false);
+  });
+});

--- a/src/settings/voice-settings-category.test.ts
+++ b/src/settings/voice-settings-category.test.ts
@@ -6,10 +6,21 @@ import { DEFAULT_STT_SETTINGS, type STTSettings } from '../stt';
 import {
   VOICE_SAVED_INDICATOR_MS,
   createVoiceSettingsCategoryController,
+  type VoiceSettingsCategoryController,
+  type VoiceSettingsCategoryControllerOptions,
 } from './voice-settings-category';
+
+const controllers: VoiceSettingsCategoryController[] = [];
+
+function createController(options: VoiceSettingsCategoryControllerOptions) {
+  const controller = createVoiceSettingsCategoryController(options);
+  controllers.push(controller);
+  return controller;
+}
 
 describe('voice settings category controller', () => {
   afterEach(() => {
+    controllers.splice(0).forEach((controller) => controller.dispose());
     vi.useRealTimers();
   });
 
@@ -20,10 +31,7 @@ describe('voice settings category controller', () => {
     };
     const loadVoiceSettings = vi.fn(async () => savedSettings);
     const saveVoiceSettings = vi.fn(async () => true);
-    const controller = createVoiceSettingsCategoryController({
-      loadVoiceSettings,
-      saveVoiceSettings,
-    });
+    const controller = createController({ loadVoiceSettings, saveVoiceSettings });
 
     await controller.load();
     expect(controller.getSnapshot().sttSettings).toEqual(savedSettings);
@@ -41,9 +49,43 @@ describe('voice settings category controller', () => {
     expect(controller.getSnapshot().voiceSaved).toBe(true);
   });
 
+  it('keeps newer draft changes when an earlier save finishes', async () => {
+    let finishSave: (saved: boolean) => void = () => {};
+    const saveVoiceSettings = vi.fn(() => new Promise<boolean>((resolve) => {
+      finishSave = resolve;
+    }));
+    const controller = createController({
+      loadVoiceSettings: vi.fn(async () => DEFAULT_STT_SETTINGS),
+      saveVoiceSettings,
+    });
+
+    controller.setSttSettings({
+      provider: 'deepgram',
+      deepgramApiKey: 'saved-key',
+    });
+    const save = controller.save();
+    controller.setSttSettings((current) => ({
+      ...current,
+      deepgramApiKey: 'newer-draft-key',
+    }));
+
+    finishSave(true);
+    await save;
+
+    expect(saveVoiceSettings).toHaveBeenCalledWith({
+      provider: 'deepgram',
+      deepgramApiKey: 'saved-key',
+    });
+    expect(controller.getSnapshot().sttSettings).toEqual({
+      provider: 'deepgram',
+      deepgramApiKey: 'newer-draft-key',
+    });
+    expect(controller.getSnapshot().voiceSaved).toBe(true);
+  });
+
   it('hides the saved indicator after the confirmation timeout', async () => {
     vi.useFakeTimers();
-    const controller = createVoiceSettingsCategoryController({
+    const controller = createController({
       loadVoiceSettings: vi.fn(async () => DEFAULT_STT_SETTINGS),
       saveVoiceSettings: vi.fn(async () => true),
     });

--- a/src/settings/voice-settings-category.ts
+++ b/src/settings/voice-settings-category.ts
@@ -80,10 +80,7 @@ class DefaultVoiceSettingsCategoryController implements VoiceSettingsCategoryCon
     const loadedSettings = await this.loadVoiceSettings();
     if (this.disposed || generation !== this.loadGeneration || !loadedSettings) return;
 
-    this.replaceSnapshot({
-      ...this.snapshot,
-      sttSettings: mergeVoiceSettings(loadedSettings),
-    });
+    this.updateSnapshot({ sttSettings: mergeVoiceSettings(loadedSettings) });
   }
 
   setSttSettings(update: SetStateAction<STTSettings>): void {
@@ -91,18 +88,15 @@ class DefaultVoiceSettingsCategoryController implements VoiceSettingsCategoryCon
       ? update(this.snapshot.sttSettings)
       : update;
 
-    this.replaceSnapshot({
-      ...this.snapshot,
-      sttSettings: mergeVoiceSettings(nextSettings),
-    });
+    this.updateSnapshot({ sttSettings: mergeVoiceSettings(nextSettings) });
   }
 
   async save(): Promise<void> {
-    const settings = mergeVoiceSettings(this.snapshot.sttSettings);
-    const saved = await this.saveVoiceSettings(settings);
+    const settingsToSave = mergeVoiceSettings(this.snapshot.sttSettings);
+    const saved = await this.saveVoiceSettings(settingsToSave);
     if (this.disposed || !saved) return;
 
-    this.replaceSnapshot({ ...this.snapshot, sttSettings: settings, voiceSaved: true });
+    this.updateSnapshot({ voiceSaved: true });
     this.restartSavedTimer();
   }
 
@@ -127,7 +121,7 @@ class DefaultVoiceSettingsCategoryController implements VoiceSettingsCategoryCon
     this.savedTimer = this.setSavedTimer(() => {
       this.savedTimer = null;
       if (this.disposed) return;
-      this.replaceSnapshot({ ...this.snapshot, voiceSaved: false });
+      this.updateSnapshot({ voiceSaved: false });
     }, VOICE_SAVED_INDICATOR_MS);
   }
 
@@ -135,6 +129,10 @@ class DefaultVoiceSettingsCategoryController implements VoiceSettingsCategoryCon
     if (!this.savedTimer) return;
     this.clearSavedTimer(this.savedTimer);
     this.savedTimer = null;
+  }
+
+  private updateSnapshot(patch: Partial<VoiceSettingsCategorySnapshot>): void {
+    this.replaceSnapshot({ ...this.snapshot, ...patch });
   }
 
   private replaceSnapshot(snapshot: VoiceSettingsCategorySnapshot): void {

--- a/src/settings/voice-settings-category.ts
+++ b/src/settings/voice-settings-category.ts
@@ -1,0 +1,182 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+import { Platform } from 'react-native';
+
+import {
+  createDefaultVoiceSettings,
+  loadVoiceSettings as loadStoredVoiceSettings,
+  mergeVoiceSettings,
+  saveVoiceSettings as saveStoredVoiceSettings,
+} from '../storage/app-data';
+import type { STTSettings } from '../stt';
+
+export const VOICE_SAVED_INDICATOR_MS = 2000;
+
+type SavedTimer = ReturnType<typeof setTimeout>;
+type VoiceSettingsListener = (snapshot: VoiceSettingsCategorySnapshot) => void;
+
+export interface VoiceSettingsCategorySnapshot {
+  sttSettings: STTSettings;
+  voiceSaved: boolean;
+}
+
+export interface VoiceSettingsCategoryControllerOptions {
+  loadVoiceSettings?: () => Promise<STTSettings | null>;
+  saveVoiceSettings?: (settings: STTSettings) => Promise<boolean>;
+  setSavedTimer?: (callback: () => void, ms: number) => SavedTimer;
+  clearSavedTimer?: (timer: SavedTimer) => void;
+}
+
+export interface VoiceSettingsCategoryController {
+  getSnapshot(): VoiceSettingsCategorySnapshot;
+  subscribe(listener: VoiceSettingsListener): () => void;
+  load(): Promise<void>;
+  setSttSettings(update: SetStateAction<STTSettings>): void;
+  save(): Promise<void>;
+  reset(): void;
+  dispose(): void;
+}
+
+class DefaultVoiceSettingsCategoryController implements VoiceSettingsCategoryController {
+  private readonly loadVoiceSettings: () => Promise<STTSettings | null>;
+  private readonly saveVoiceSettings: (settings: STTSettings) => Promise<boolean>;
+  private readonly setSavedTimer: (callback: () => void, ms: number) => SavedTimer;
+  private readonly clearSavedTimer: (timer: SavedTimer) => void;
+  private readonly listeners = new Set<VoiceSettingsListener>();
+  private snapshot: VoiceSettingsCategorySnapshot = {
+    sttSettings: createDefaultVoiceSettings(),
+    voiceSaved: false,
+  };
+  private savedTimer: SavedTimer | null = null;
+  private loadGeneration = 0;
+  private disposed = false;
+
+  constructor(options: VoiceSettingsCategoryControllerOptions = {}) {
+    this.loadVoiceSettings = options.loadVoiceSettings ?? loadStoredVoiceSettings;
+    this.saveVoiceSettings = options.saveVoiceSettings ?? saveStoredVoiceSettings;
+    this.setSavedTimer = options.setSavedTimer ?? setTimeout;
+    this.clearSavedTimer = options.clearSavedTimer ?? clearTimeout;
+  }
+
+  getSnapshot(): VoiceSettingsCategorySnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(listener: VoiceSettingsListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async load(): Promise<void> {
+    const generation = ++this.loadGeneration;
+    const loadedSettings = await this.loadVoiceSettings();
+    if (this.disposed || generation !== this.loadGeneration || !loadedSettings) return;
+
+    this.replaceSnapshot({
+      ...this.snapshot,
+      sttSettings: mergeVoiceSettings(loadedSettings),
+    });
+  }
+
+  setSttSettings(update: SetStateAction<STTSettings>): void {
+    const nextSettings = typeof update === 'function'
+      ? update(this.snapshot.sttSettings)
+      : update;
+
+    this.replaceSnapshot({
+      ...this.snapshot,
+      sttSettings: mergeVoiceSettings(nextSettings),
+    });
+  }
+
+  async save(): Promise<void> {
+    const settings = mergeVoiceSettings(this.snapshot.sttSettings);
+    const saved = await this.saveVoiceSettings(settings);
+    if (this.disposed || !saved) return;
+
+    this.replaceSnapshot({ ...this.snapshot, sttSettings: settings, voiceSaved: true });
+    this.restartSavedTimer();
+  }
+
+  reset(): void {
+    this.loadGeneration += 1;
+    this.clearSavedIndicatorTimer();
+    this.replaceSnapshot({
+      sttSettings: createDefaultVoiceSettings(),
+      voiceSaved: false,
+    });
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.loadGeneration += 1;
+    this.clearSavedIndicatorTimer();
+    this.listeners.clear();
+  }
+
+  private restartSavedTimer(): void {
+    this.clearSavedIndicatorTimer();
+    this.savedTimer = this.setSavedTimer(() => {
+      this.savedTimer = null;
+      if (this.disposed) return;
+      this.replaceSnapshot({ ...this.snapshot, voiceSaved: false });
+    }, VOICE_SAVED_INDICATOR_MS);
+  }
+
+  private clearSavedIndicatorTimer(): void {
+    if (!this.savedTimer) return;
+    this.clearSavedTimer(this.savedTimer);
+    this.savedTimer = null;
+  }
+
+  private replaceSnapshot(snapshot: VoiceSettingsCategorySnapshot): void {
+    this.snapshot = snapshot;
+    this.listeners.forEach((listener) => listener(this.snapshot));
+  }
+}
+
+export function createVoiceSettingsCategoryController(
+  options: VoiceSettingsCategoryControllerOptions = {},
+): VoiceSettingsCategoryController {
+  return new DefaultVoiceSettingsCategoryController(options);
+}
+
+export function useVoiceSettingsCategory() {
+  const controllerRef = useRef<VoiceSettingsCategoryController | null>(null);
+  if (!controllerRef.current) {
+    controllerRef.current = createVoiceSettingsCategoryController();
+  }
+  const controller = controllerRef.current;
+  const [snapshot, setSnapshot] = useState(() => controller.getSnapshot());
+
+  useEffect(() => controller.subscribe(setSnapshot), [controller]);
+
+  useEffect(() => {
+    void controller.load();
+    return () => controller.dispose();
+  }, [controller]);
+
+  const setSttSettings = useCallback<Dispatch<SetStateAction<STTSettings>>>((update) => {
+    controller.setSttSettings(update);
+  }, [controller]);
+
+  const saveVoice = useCallback(() => controller.save(), [controller]);
+  const resetVoiceSettings = useCallback(() => controller.reset(), [controller]);
+
+  return {
+    sttSettings: snapshot.sttSettings,
+    setSttSettings,
+    saveVoice,
+    voiceSaved: snapshot.voiceSaved,
+    isWebSpeech: Platform.OS === 'web',
+    resetVoiceSettings,
+  };
+}

--- a/src/storage/app-data-core.ts
+++ b/src/storage/app-data-core.ts
@@ -1,0 +1,135 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { STT_SETTINGS_KEY } from '../stt';
+import {
+  CARD_SIZE_KEY,
+  COLOR_SCHEME_KEY,
+  DATA_SOURCES_KEY,
+  SRD_CACHE_KEY_PREFIX,
+  UPLOADS_KEY,
+} from './keys';
+
+const APP_STORAGE_PREFIXES = ['dndref:', '@dnd-ref/'];
+const INVALID_APP_DATA_TOKEN = -1;
+
+let appDataResetGeneration = 0;
+let appDataResetActive = false;
+let cacheWritesBlockedForGeneration: number | null = null;
+let appDataWriteQueue: Promise<unknown> = Promise.resolve();
+
+export const APP_STORAGE_KEYS = [
+  DATA_SOURCES_KEY,
+  UPLOADS_KEY,
+  STT_SETTINGS_KEY,
+  CARD_SIZE_KEY,
+  COLOR_SCHEME_KEY,
+];
+
+export function isAppStorageKey(key: string): boolean {
+  return (
+    APP_STORAGE_KEYS.includes(key) ||
+    key.startsWith(SRD_CACHE_KEY_PREFIX) ||
+    APP_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
+  );
+}
+
+export function createAppDataWriteToken(): number {
+  return appDataResetActive ? INVALID_APP_DATA_TOKEN : appDataResetGeneration;
+}
+
+export function isAppDataWriteTokenCurrent(token: number): boolean {
+  return token !== INVALID_APP_DATA_TOKEN &&
+    token === appDataResetGeneration &&
+    !appDataResetActive;
+}
+
+export function canPersistAppData(token: number): boolean {
+  return isAppDataWriteTokenCurrent(token);
+}
+
+export function canPersistAppDataCache(token: number): boolean {
+  return canPersistAppData(token) && cacheWritesBlockedForGeneration !== token;
+}
+
+export function allowAppDataCacheWrites(): void {
+  cacheWritesBlockedForGeneration = null;
+}
+
+export interface AppDataCacheSession {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<boolean>;
+}
+
+export function createAppDataCacheSession(): AppDataCacheSession {
+  const token = createAppDataWriteToken();
+  return {
+    getItem: (key) => getAppDataItem(key, token),
+    setItem: (key, value) => setAppDataItem(key, value, { cache: true, token }),
+  };
+}
+
+export async function getAppDataItem(
+  key: string,
+  token = createAppDataWriteToken(),
+): Promise<string | null> {
+  const value = await AsyncStorage.getItem(key);
+  return isAppDataWriteTokenCurrent(token) ? value : null;
+}
+
+export async function setAppDataItem(
+  key: string,
+  value: string,
+  options: { cache?: boolean; token?: number } = {},
+): Promise<boolean> {
+  const { cache = false, token = createAppDataWriteToken() } = options;
+  const operation = appDataWriteQueue
+    .catch(() => undefined)
+    .then(async () => {
+      const canPersist = cache ? canPersistAppDataCache : canPersistAppData;
+      if (!canPersist(token)) return false;
+
+      await AsyncStorage.setItem(key, value);
+      const saved = canPersist(token);
+      if (saved && !cache) allowAppDataCacheWrites();
+      return saved;
+    });
+
+  appDataWriteQueue = operation.catch(() => undefined);
+  return operation;
+}
+
+export async function waitForAppDataWrites(): Promise<void> {
+  await appDataWriteQueue.catch(() => undefined);
+}
+
+export function beginAppDataReset(): number {
+  appDataResetGeneration += 1;
+  appDataResetActive = true;
+  return appDataResetGeneration;
+}
+
+export function finishAppDataReset(generation: number): void {
+  if (generation !== appDataResetGeneration) return;
+  appDataResetActive = false;
+  cacheWritesBlockedForGeneration = generation;
+}
+
+export async function getStoredAppDataKeys(): Promise<string[]> {
+  const keys = await AsyncStorage.getAllKeys();
+  return Array.from(new Set(keys.filter(isAppStorageKey)));
+}
+
+export async function clearStoredAppData(): Promise<string[]> {
+  const keys = await getStoredAppDataKeys();
+  if (keys.length > 0) {
+    await AsyncStorage.multiRemove(keys);
+  }
+  return keys;
+}
+
+export function resetAppDataCoreControlsForTests(): void {
+  appDataResetGeneration = 0;
+  appDataResetActive = false;
+  cacheWritesBlockedForGeneration = null;
+  appDataWriteQueue = Promise.resolve();
+}

--- a/src/storage/app-data-settings.ts
+++ b/src/storage/app-data-settings.ts
@@ -1,0 +1,142 @@
+import { DEFAULT_STT_SETTINGS, STT_SETTINGS_KEY, type STTSettings } from '../stt';
+import { DATA_SOURCES_KEY } from './keys';
+import { getAppDataItem, setAppDataItem } from './app-data-core';
+
+export interface DataSourcesSettings {
+  srdEnabled: boolean;
+  srdSources: string[];
+  kankaToken: string;
+  kankaCampaignId: string;
+  homebreweryUrl: string;
+  notionToken: string;
+  notionPageIds: string;
+  googleDocsUrl: string;
+  aiApiKey: string;
+}
+
+export const DEFAULT_DATA_SOURCES_SETTINGS: DataSourcesSettings = {
+  srdEnabled: true,
+  srdSources: ['wotc-srd'],
+  kankaToken: '',
+  kankaCampaignId: '',
+  homebreweryUrl: '',
+  notionToken: '',
+  notionPageIds: '',
+  googleDocsUrl: '',
+  aiApiKey: '',
+};
+
+export function createDefaultDataSourceSettings(): DataSourcesSettings {
+  return {
+    ...DEFAULT_DATA_SOURCES_SETTINGS,
+    srdSources: [...DEFAULT_DATA_SOURCES_SETTINGS.srdSources],
+  };
+}
+
+export function mergeDataSourceSettings(
+  settings?: Partial<DataSourcesSettings> | null,
+): DataSourcesSettings {
+  const patch = settings ?? {};
+  const defaultSettings = createDefaultDataSourceSettings();
+  const srdSources = Array.isArray(patch.srdSources)
+    ? [...patch.srdSources]
+    : defaultSettings.srdSources;
+
+  return {
+    ...defaultSettings,
+    ...patch,
+    srdSources,
+  };
+}
+
+type VoiceSettingsPatch = Partial<Record<keyof STTSettings, unknown>>;
+
+function isVoiceSettingsPatch(value: unknown): value is VoiceSettingsPatch {
+  return value !== null && typeof value === 'object';
+}
+
+function isVoiceProvider(value: unknown): value is STTSettings['provider'] {
+  return value === 'deepgram' || value === 'web-speech';
+}
+
+export function createDefaultVoiceSettings(): STTSettings {
+  return { ...DEFAULT_STT_SETTINGS };
+}
+
+function normalizeVoiceSettings(settings: unknown): STTSettings {
+  const patch = isVoiceSettingsPatch(settings) ? settings : {};
+  const defaultSettings = createDefaultVoiceSettings();
+
+  const provider = isVoiceProvider(patch.provider)
+    ? patch.provider
+    : defaultSettings.provider;
+  const deepgramApiKey = typeof patch.deepgramApiKey === 'string'
+    ? patch.deepgramApiKey
+    : defaultSettings.deepgramApiKey;
+
+  return { provider, deepgramApiKey };
+}
+
+export function mergeVoiceSettings(settings?: Partial<STTSettings> | null): STTSettings {
+  return normalizeVoiceSettings(settings);
+}
+
+export async function loadVoiceSettings(): Promise<STTSettings | null> {
+  let raw: string | null;
+  try {
+    raw = await getAppDataItem(STT_SETTINGS_KEY);
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to load voice settings:', e);
+    return null;
+  }
+
+  if (!raw) return null;
+
+  try {
+    return normalizeVoiceSettings(JSON.parse(raw));
+  } catch (parseErr) {
+    console.warn('[dnd-ref] Failed to parse voice settings:', parseErr);
+    return null;
+  }
+}
+
+export async function saveVoiceSettings(settings: STTSettings): Promise<boolean> {
+  const serializedSettings = JSON.stringify(mergeVoiceSettings(settings));
+
+  try {
+    return await setAppDataItem(STT_SETTINGS_KEY, serializedSettings);
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to save voice settings:', e);
+    return false;
+  }
+}
+
+export async function loadDataSourceSettings(): Promise<DataSourcesSettings | null> {
+  let raw: string | null;
+  try {
+    raw = await getAppDataItem(DATA_SOURCES_KEY);
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to load data source settings:', e);
+    return null;
+  }
+
+  if (!raw) return null;
+
+  try {
+    return mergeDataSourceSettings(JSON.parse(raw) as Partial<DataSourcesSettings>);
+  } catch (parseErr) {
+    console.warn('[dnd-ref] Failed to parse data source settings:', parseErr);
+    return null;
+  }
+}
+
+export async function saveDataSourceSettings(settings: DataSourcesSettings): Promise<boolean> {
+  const serializedSettings = JSON.stringify(settings);
+
+  try {
+    return await setAppDataItem(DATA_SOURCES_KEY, serializedSettings);
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to save data source settings:', e);
+    return false;
+  }
+}

--- a/src/storage/app-data-uploads.ts
+++ b/src/storage/app-data-uploads.ts
@@ -1,0 +1,81 @@
+import { UPLOADS_KEY } from './keys';
+import {
+  canPersistAppData,
+  createAppDataWriteToken,
+  getAppDataItem,
+  setAppDataItem,
+} from './app-data-core';
+
+export interface UploadedFile {
+  id: string;
+  name: string;
+  content: string;
+}
+
+let uploadMutationQueue: Promise<unknown> = Promise.resolve();
+
+export async function getUploadedFiles(): Promise<UploadedFile[]> {
+  return readUploadedFiles(createAppDataWriteToken());
+}
+
+export async function addUploadedFile(name: string, content: string): Promise<boolean> {
+  return mutateUploadedFiles((uploads) => [...uploads, createUploadedFile(name, content)]);
+}
+
+export async function removeUploadedFile(id: string): Promise<boolean> {
+  return mutateUploadedFiles((uploads) => uploads.filter((u) => u.id !== id));
+}
+
+export async function waitForUploadedFileMutations(): Promise<void> {
+  await uploadMutationQueue.catch(() => undefined);
+}
+
+function createUploadedFile(name: string, content: string): UploadedFile {
+  return {
+    id: `upload-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    name,
+    content,
+  };
+}
+
+function isUploadedFile(value: unknown): value is UploadedFile {
+  if (!value || typeof value !== 'object') return false;
+
+  const file = value as Record<string, unknown>;
+  return typeof file.id === 'string' &&
+    typeof file.name === 'string' &&
+    typeof file.content === 'string';
+}
+
+async function readUploadedFiles(token: number): Promise<UploadedFile[]> {
+  try {
+    const raw = await getAppDataItem(UPLOADS_KEY, token);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter(isUploadedFile) : [];
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to read uploads from storage:', e);
+    return [];
+  }
+}
+
+function mutateUploadedFiles(mutator: (uploads: UploadedFile[]) => UploadedFile[]): Promise<boolean> {
+  const token = createAppDataWriteToken();
+  const operation = uploadMutationQueue
+    .catch(() => undefined)
+    .then(async () => {
+      if (!canPersistAppData(token)) return false;
+      const currentUploads = await readUploadedFiles(token);
+      if (!canPersistAppData(token)) return false;
+
+      const nextUploads = mutator(currentUploads);
+      return setAppDataItem(UPLOADS_KEY, JSON.stringify(nextUploads), { token });
+    });
+
+  uploadMutationQueue = operation.catch(() => undefined);
+  return operation;
+}
+
+export function resetUploadedFileMutationQueueForTests(): void {
+  uploadMutationQueue = Promise.resolve();
+}

--- a/src/storage/app-data.test.ts
+++ b/src/storage/app-data.test.ts
@@ -25,6 +25,7 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
 
 import {
   APP_STORAGE_KEYS,
+  DEFAULT_DATA_SOURCES_SETTINGS,
   allowAppDataCacheWrites,
   beginAppDataReset,
   canPersistAppDataCache,
@@ -32,8 +33,10 @@ import {
   finishAppDataReset,
   getAppDataItem,
   isAppStorageKey,
+  loadDataSourceSettings,
   resetAppDataControlsForTests,
   resetStoredAppData,
+  saveDataSourceSettings,
   setAppDataItem,
 } from './app-data';
 import {
@@ -145,5 +148,73 @@ describe('app data storage clearing', () => {
     releaseGetItem();
 
     expect(await read).toBeNull();
+  });
+
+  it('loads data source settings through the local app data seam', async () => {
+    storage.set(DATA_SOURCES_KEY, JSON.stringify({
+      srdEnabled: false,
+      kankaToken: 'kanka-secret',
+      srdSources: ['kobold-press-tob'],
+    }));
+
+    await expect(loadDataSourceSettings()).resolves.toEqual({
+      ...DEFAULT_DATA_SOURCES_SETTINGS,
+      srdEnabled: false,
+      kankaToken: 'kanka-secret',
+      srdSources: ['kobold-press-tob'],
+    });
+  });
+
+  it('saves data source settings through the local app data seam', async () => {
+    await resetStoredAppData();
+    const cacheWriteToken = createAppDataWriteToken();
+    const settings = {
+      ...DEFAULT_DATA_SOURCES_SETTINGS,
+      googleDocsUrl: 'https://docs.google.com/document/d/campaign',
+    };
+
+    expect(canPersistAppDataCache(cacheWriteToken)).toBe(false);
+    await expect(saveDataSourceSettings(settings)).resolves.toBe(true);
+
+    expect(JSON.parse(storage.get(DATA_SOURCES_KEY)!)).toEqual(settings);
+    expect(canPersistAppDataCache(cacheWriteToken)).toBe(true);
+  });
+
+  it('drops stale data source settings hydration through the local app data seam', async () => {
+    storage.set(DATA_SOURCES_KEY, JSON.stringify({ aiApiKey: 'stale-secret' }));
+    let releaseGetItem!: () => void;
+    storageControls.getItemGate = new Promise((resolve) => {
+      releaseGetItem = resolve;
+    });
+
+    const read = loadDataSourceSettings();
+    await Promise.resolve();
+
+    const generation = beginAppDataReset();
+    finishAppDataReset(generation);
+    releaseGetItem();
+
+    await expect(read).resolves.toBeNull();
+  });
+
+  it('drops stale data source settings writes through the local app data seam', async () => {
+    let releaseSetItem!: () => void;
+    storageControls.setItemGate = new Promise((resolve) => {
+      releaseSetItem = resolve;
+    });
+
+    const write = saveDataSourceSettings({
+      ...DEFAULT_DATA_SOURCES_SETTINGS,
+      aiApiKey: 'secret',
+    });
+    await Promise.resolve();
+
+    const reset = resetStoredAppData();
+    releaseSetItem();
+
+    await expect(write).resolves.toBe(false);
+    await reset;
+
+    expect(storage.get(DATA_SOURCES_KEY)).toBeUndefined();
   });
 });

--- a/src/storage/app-data.test.ts
+++ b/src/storage/app-data.test.ts
@@ -26,14 +26,18 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
 import {
   APP_STORAGE_KEYS,
   DEFAULT_DATA_SOURCES_SETTINGS,
+  addUploadedFile,
   allowAppDataCacheWrites,
   beginAppDataReset,
   canPersistAppDataCache,
+  createAppDataCacheSession,
   createAppDataWriteToken,
   finishAppDataReset,
   getAppDataItem,
+  getUploadedFiles,
   isAppStorageKey,
   loadDataSourceSettings,
+  removeUploadedFile,
   resetAppDataControlsForTests,
   resetStoredAppData,
   saveDataSourceSettings,
@@ -103,6 +107,32 @@ describe('app data storage clearing', () => {
     ].sort());
   });
 
+  it('adds, removes, and reads uploaded files through the local app data seam', async () => {
+    await expect(addUploadedFile('one.md', '# One')).resolves.toBe(true);
+    await expect(addUploadedFile('two.md', '# Two')).resolves.toBe(true);
+
+    const [first] = await getUploadedFiles();
+    await expect(removeUploadedFile(first.id)).resolves.toBe(true);
+
+    expect((await getUploadedFiles()).map((u) => u.name)).toEqual(['two.md']);
+  });
+
+  it('waits for in-flight upload mutations before clearing storage', async () => {
+    const releaseGetItem = blockStorageOperation('getItemGate');
+
+    const upload = addUploadedFile('late.md', '# Late');
+    await Promise.resolve();
+
+    const reset = resetStoredAppData();
+    releaseGetItem();
+
+    await Promise.all([upload, reset]);
+    storageControls.getItemGate = null;
+
+    expect(await getUploadedFiles()).toEqual([]);
+    expect(storage.get('unrelated:other-app')).toBe('keep');
+  });
+
   it('invalidates stale async write tokens after a reset starts', () => {
     const token = createAppDataWriteToken();
     const generation = beginAppDataReset();
@@ -122,6 +152,22 @@ describe('app data storage clearing', () => {
 
     allowAppDataCacheWrites();
     expect(canPersistAppDataCache(token)).toBe(true);
+  });
+
+  it('routes cache writes through sessions and re-allows them after non-cache app data writes', async () => {
+    await resetStoredAppData();
+    const blockedCache = createAppDataCacheSession();
+    const blockedKey = `${SRD_CACHE_KEY_PREFIX}blocked`;
+    const allowedKey = `${SRD_CACHE_KEY_PREFIX}allowed`;
+
+    await expect(blockedCache.setItem(blockedKey, '{}')).resolves.toBe(false);
+    expect(storage.has(blockedKey)).toBe(false);
+
+    await expect(setAppDataItem(CARD_SIZE_KEY, 'L')).resolves.toBe(true);
+
+    const allowedCache = createAppDataCacheSession();
+    await expect(allowedCache.setItem(allowedKey, '{}')).resolves.toBe(true);
+    expect(storage.get(allowedKey)).toBe('{}');
   });
 
   it('waits for in-flight settings writes before clearing storage', async () => {

--- a/src/storage/app-data.test.ts
+++ b/src/storage/app-data.test.ts
@@ -48,6 +48,14 @@ import {
 } from './keys';
 import { STT_SETTINGS_KEY } from '../stt';
 
+function blockStorageOperation(operation: keyof typeof storageControls): () => void {
+  let releaseGate = () => {};
+  storageControls[operation] = new Promise((resolve) => {
+    releaseGate = resolve;
+  });
+  return releaseGate;
+}
+
 describe('app data storage clearing', () => {
   beforeEach(() => {
     resetAppDataControlsForTests();
@@ -117,10 +125,7 @@ describe('app data storage clearing', () => {
   });
 
   it('waits for in-flight settings writes before clearing storage', async () => {
-    let releaseSetItem!: () => void;
-    storageControls.setItemGate = new Promise((resolve) => {
-      releaseSetItem = resolve;
-    });
+    const releaseSetItem = blockStorageOperation('setItemGate');
 
     const write = setAppDataItem(DATA_SOURCES_KEY, '{"aiApiKey":"secret"}');
     await Promise.resolve();
@@ -135,10 +140,7 @@ describe('app data storage clearing', () => {
   });
 
   it('ignores stale hydration reads that resolve after reset starts', async () => {
-    let releaseGetItem!: () => void;
-    storageControls.getItemGate = new Promise((resolve) => {
-      releaseGetItem = resolve;
-    });
+    const releaseGetItem = blockStorageOperation('getItemGate');
 
     const read = getAppDataItem(STT_SETTINGS_KEY);
     await Promise.resolve();
@@ -182,10 +184,7 @@ describe('app data storage clearing', () => {
 
   it('drops stale data source settings hydration through the local app data seam', async () => {
     storage.set(DATA_SOURCES_KEY, JSON.stringify({ aiApiKey: 'stale-secret' }));
-    let releaseGetItem!: () => void;
-    storageControls.getItemGate = new Promise((resolve) => {
-      releaseGetItem = resolve;
-    });
+    const releaseGetItem = blockStorageOperation('getItemGate');
 
     const read = loadDataSourceSettings();
     await Promise.resolve();
@@ -198,10 +197,7 @@ describe('app data storage clearing', () => {
   });
 
   it('drops stale data source settings writes through the local app data seam', async () => {
-    let releaseSetItem!: () => void;
-    storageControls.setItemGate = new Promise((resolve) => {
-      releaseSetItem = resolve;
-    });
+    const releaseSetItem = blockStorageOperation('setItemGate');
 
     const write = saveDataSourceSettings({
       ...DEFAULT_DATA_SOURCES_SETTINGS,

--- a/src/storage/app-data.test.ts
+++ b/src/storage/app-data.test.ts
@@ -34,9 +34,11 @@ import {
   getAppDataItem,
   isAppStorageKey,
   loadDataSourceSettings,
+  loadVoiceSettings,
   resetAppDataControlsForTests,
   resetStoredAppData,
   saveDataSourceSettings,
+  saveVoiceSettings,
   setAppDataItem,
 } from './app-data';
 import {
@@ -46,7 +48,7 @@ import {
   SRD_CACHE_KEY_PREFIX,
   UPLOADS_KEY,
 } from './keys';
-import { STT_SETTINGS_KEY } from '../stt';
+import { DEFAULT_STT_SETTINGS, STT_SETTINGS_KEY } from '../stt';
 
 function blockStorageOperation(operation: keyof typeof storageControls): () => void {
   let releaseGate = () => {};
@@ -150,6 +152,26 @@ describe('app data storage clearing', () => {
     releaseGetItem();
 
     expect(await read).toBeNull();
+  });
+
+  it('loads and saves voice settings through the local app data seam', async () => {
+    const settings = {
+      provider: 'deepgram' as const,
+      deepgramApiKey: 'voice-secret',
+    };
+
+    await expect(saveVoiceSettings(settings)).resolves.toBe(true);
+    expect(JSON.parse(storage.get(STT_SETTINGS_KEY)!)).toEqual(settings);
+    await expect(loadVoiceSettings()).resolves.toEqual(settings);
+  });
+
+  it('validates loaded voice settings through the local app data seam', async () => {
+    storage.set(STT_SETTINGS_KEY, JSON.stringify({
+      provider: 'bogus-provider',
+      deepgramApiKey: 42,
+    }));
+
+    await expect(loadVoiceSettings()).resolves.toEqual(DEFAULT_STT_SETTINGS);
   });
 
   it('loads data source settings through the local app data seam', async () => {

--- a/src/storage/app-data.ts
+++ b/src/storage/app-data.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import { STT_SETTINGS_KEY } from '../stt';
+import { DEFAULT_STT_SETTINGS, STT_SETTINGS_KEY, type STTSettings } from '../stt';
 import {
   CARD_SIZE_KEY,
   COLOR_SCHEME_KEY,
@@ -100,6 +100,51 @@ export function mergeDataSourceSettings(
     ...patch,
     srdSources,
   };
+}
+
+export function createDefaultVoiceSettings(): STTSettings {
+  return { ...DEFAULT_STT_SETTINGS };
+}
+
+export function mergeVoiceSettings(settings?: Partial<STTSettings> | null): STTSettings {
+  const provider = settings?.provider === 'deepgram' || settings?.provider === 'web-speech'
+    ? settings.provider
+    : DEFAULT_STT_SETTINGS.provider;
+  const deepgramApiKey = typeof settings?.deepgramApiKey === 'string'
+    ? settings.deepgramApiKey
+    : DEFAULT_STT_SETTINGS.deepgramApiKey;
+
+  return { provider, deepgramApiKey };
+}
+
+export async function loadVoiceSettings(): Promise<STTSettings | null> {
+  let raw: string | null;
+  try {
+    raw = await getAppDataItem(STT_SETTINGS_KEY);
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to load voice settings:', e);
+    return null;
+  }
+
+  if (!raw) return null;
+
+  try {
+    return mergeVoiceSettings(JSON.parse(raw) as Partial<STTSettings>);
+  } catch (parseErr) {
+    console.warn('[dnd-ref] Failed to parse voice settings:', parseErr);
+    return null;
+  }
+}
+
+export async function saveVoiceSettings(settings: STTSettings): Promise<boolean> {
+  const serializedSettings = JSON.stringify(mergeVoiceSettings(settings));
+
+  try {
+    return await setAppDataItem(STT_SETTINGS_KEY, serializedSettings);
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to save voice settings:', e);
+    return false;
+  }
 }
 
 export async function loadDataSourceSettings(): Promise<DataSourcesSettings | null> {

--- a/src/storage/app-data.ts
+++ b/src/storage/app-data.ts
@@ -12,6 +12,12 @@ import {
 const APP_STORAGE_PREFIXES = ['dndref:', '@dnd-ref/'];
 const INVALID_APP_DATA_TOKEN = -1;
 
+export interface UploadedFile {
+  id: string;
+  name: string;
+  content: string;
+}
+
 export interface DataSourcesSettings {
   srdEnabled: boolean;
   srdSources: string[];
@@ -40,6 +46,7 @@ let appDataResetGeneration = 0;
 let appDataResetActive = false;
 let cacheWritesBlockedForGeneration: number | null = null;
 let appDataWriteQueue: Promise<unknown> = Promise.resolve();
+let uploadMutationQueue: Promise<unknown> = Promise.resolve();
 
 export const APP_STORAGE_KEYS = [
   DATA_SOURCES_KEY,
@@ -125,13 +132,78 @@ export async function saveDataSourceSettings(settings: DataSourcesSettings): Pro
   const serializedSettings = JSON.stringify(settings);
 
   try {
-    const saved = await setAppDataItem(DATA_SOURCES_KEY, serializedSettings);
-    if (saved) allowAppDataCacheWrites();
-    return saved;
+    return await setAppDataItem(DATA_SOURCES_KEY, serializedSettings);
   } catch (e) {
     console.warn('[dnd-ref] Failed to save data source settings:', e);
     return false;
   }
+}
+
+export async function getUploadedFiles(): Promise<UploadedFile[]> {
+  return readUploadedFiles(createAppDataWriteToken());
+}
+
+export async function addUploadedFile(name: string, content: string): Promise<boolean> {
+  return mutateUploadedFiles((uploads) => {
+    const id = `upload-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    return [...uploads, { id, name, content }];
+  });
+}
+
+export async function removeUploadedFile(id: string): Promise<boolean> {
+  return mutateUploadedFiles((uploads) => uploads.filter((u) => u.id !== id));
+}
+
+export async function waitForUploadedFileMutations(): Promise<void> {
+  await uploadMutationQueue.catch(() => undefined);
+}
+
+function isUploadedFile(value: unknown): value is UploadedFile {
+  return !!value &&
+    typeof value === 'object' &&
+    typeof (value as UploadedFile).id === 'string' &&
+    typeof (value as UploadedFile).name === 'string' &&
+    typeof (value as UploadedFile).content === 'string';
+}
+
+async function readUploadedFiles(token: number): Promise<UploadedFile[]> {
+  try {
+    const raw = await getAppDataItem(UPLOADS_KEY, token);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter(isUploadedFile) : [];
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to read uploads from storage:', e);
+    return [];
+  }
+}
+
+function mutateUploadedFiles(mutator: (uploads: UploadedFile[]) => UploadedFile[]): Promise<boolean> {
+  const token = createAppDataWriteToken();
+  const operation = uploadMutationQueue
+    .catch(() => undefined)
+    .then(async () => {
+      if (!canPersistAppData(token)) return false;
+      const uploads = await readUploadedFiles(token);
+      if (!canPersistAppData(token)) return false;
+      return setAppDataItem(UPLOADS_KEY, JSON.stringify(mutator(uploads)), { token });
+    });
+
+  uploadMutationQueue = operation.catch(() => undefined);
+  return operation;
+}
+
+export interface AppDataCacheSession {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<boolean>;
+}
+
+export function createAppDataCacheSession(): AppDataCacheSession {
+  const token = createAppDataWriteToken();
+  return {
+    getItem: (key) => getAppDataItem(key, token),
+    setItem: (key, value) => setAppDataItem(key, value, { cache: true, token }),
+  };
 }
 
 export async function getAppDataItem(key: string, token = createAppDataWriteToken()): Promise<string | null> {
@@ -151,7 +223,9 @@ export async function setAppDataItem(
       const canPersist = options.cache ? canPersistAppDataCache : canPersistAppData;
       if (!canPersist(token)) return false;
       await AsyncStorage.setItem(key, value);
-      return canPersist(token);
+      const saved = canPersist(token);
+      if (saved && !options.cache) allowAppDataCacheWrites();
+      return saved;
     });
 
   appDataWriteQueue = operation.catch(() => undefined);
@@ -179,6 +253,7 @@ export async function resetStoredAppData(options: {
 } = {}): Promise<string[]> {
   const generation = beginAppDataReset();
   try {
+    await waitForUploadedFileMutations();
     await options.beforeClear?.();
     await waitForAppDataWrites();
     return await clearStoredAppData();
@@ -205,4 +280,5 @@ export function resetAppDataControlsForTests(): void {
   appDataResetActive = false;
   cacheWritesBlockedForGeneration = null;
   appDataWriteQueue = Promise.resolve();
+  uploadMutationQueue = Promise.resolve();
 }

--- a/src/storage/app-data.ts
+++ b/src/storage/app-data.ts
@@ -12,6 +12,30 @@ import {
 const APP_STORAGE_PREFIXES = ['dndref:', '@dnd-ref/'];
 const INVALID_APP_DATA_TOKEN = -1;
 
+export interface DataSourcesSettings {
+  srdEnabled: boolean;
+  srdSources: string[];
+  kankaToken: string;
+  kankaCampaignId: string;
+  homebreweryUrl: string;
+  notionToken: string;
+  notionPageIds: string;
+  googleDocsUrl: string;
+  aiApiKey: string;
+}
+
+export const DEFAULT_DATA_SOURCES_SETTINGS: DataSourcesSettings = {
+  srdEnabled: true,
+  srdSources: ['wotc-srd'],
+  kankaToken: '',
+  kankaCampaignId: '',
+  homebreweryUrl: '',
+  notionToken: '',
+  notionPageIds: '',
+  googleDocsUrl: '',
+  aiApiKey: '',
+};
+
 let appDataResetGeneration = 0;
 let appDataResetActive = false;
 let cacheWritesBlockedForGeneration: number | null = null;
@@ -53,6 +77,54 @@ export function canPersistAppDataCache(token: number): boolean {
 
 export function allowAppDataCacheWrites(): void {
   cacheWritesBlockedForGeneration = null;
+}
+
+export function createDefaultDataSourceSettings(): DataSourcesSettings {
+  return {
+    ...DEFAULT_DATA_SOURCES_SETTINGS,
+    srdSources: [...DEFAULT_DATA_SOURCES_SETTINGS.srdSources],
+  };
+}
+
+export function mergeDataSourceSettings(
+  settings: Partial<DataSourcesSettings> | null = {},
+): DataSourcesSettings {
+  const patch = settings ?? {};
+  return {
+    ...createDefaultDataSourceSettings(),
+    ...patch,
+    srdSources: Array.isArray(patch.srdSources)
+      ? [...patch.srdSources]
+      : [...DEFAULT_DATA_SOURCES_SETTINGS.srdSources],
+  };
+}
+
+export async function loadDataSourceSettings(): Promise<DataSourcesSettings | null> {
+  let raw: string | null;
+  try {
+    raw = await getAppDataItem(DATA_SOURCES_KEY);
+  } catch (e) {
+    console.warn('[dnd-ref] Failed to load data source settings:', e);
+    return null;
+  }
+
+  if (!raw) return null;
+
+  try {
+    return mergeDataSourceSettings(JSON.parse(raw) as Partial<DataSourcesSettings>);
+  } catch (parseErr) {
+    console.warn('[dnd-ref] Failed to parse data source settings:', parseErr);
+    return null;
+  }
+}
+
+export async function saveDataSourceSettings(settings: DataSourcesSettings): Promise<boolean> {
+  const saved = await setAppDataItem(DATA_SOURCES_KEY, JSON.stringify(settings)).catch((e) => {
+    console.warn('[dnd-ref] Failed to save data source settings:', e);
+    return false;
+  });
+  if (saved) allowAppDataCacheWrites();
+  return saved;
 }
 
 export async function getAppDataItem(key: string, token = createAppDataWriteToken()): Promise<string | null> {

--- a/src/storage/app-data.ts
+++ b/src/storage/app-data.ts
@@ -102,19 +102,36 @@ export function mergeDataSourceSettings(
   };
 }
 
+type VoiceSettingsPatch = Partial<Record<keyof STTSettings, unknown>>;
+
+function isVoiceSettingsPatch(value: unknown): value is VoiceSettingsPatch {
+  return value !== null && typeof value === 'object';
+}
+
+function isVoiceProvider(value: unknown): value is STTSettings['provider'] {
+  return value === 'deepgram' || value === 'web-speech';
+}
+
 export function createDefaultVoiceSettings(): STTSettings {
   return { ...DEFAULT_STT_SETTINGS };
 }
 
-export function mergeVoiceSettings(settings?: Partial<STTSettings> | null): STTSettings {
-  const provider = settings?.provider === 'deepgram' || settings?.provider === 'web-speech'
-    ? settings.provider
-    : DEFAULT_STT_SETTINGS.provider;
-  const deepgramApiKey = typeof settings?.deepgramApiKey === 'string'
-    ? settings.deepgramApiKey
-    : DEFAULT_STT_SETTINGS.deepgramApiKey;
+function normalizeVoiceSettings(settings: unknown): STTSettings {
+  const patch = isVoiceSettingsPatch(settings) ? settings : {};
+  const defaultSettings = createDefaultVoiceSettings();
+
+  const provider = isVoiceProvider(patch.provider)
+    ? patch.provider
+    : defaultSettings.provider;
+  const deepgramApiKey = typeof patch.deepgramApiKey === 'string'
+    ? patch.deepgramApiKey
+    : defaultSettings.deepgramApiKey;
 
   return { provider, deepgramApiKey };
+}
+
+export function mergeVoiceSettings(settings?: Partial<STTSettings> | null): STTSettings {
+  return normalizeVoiceSettings(settings);
 }
 
 export async function loadVoiceSettings(): Promise<STTSettings | null> {
@@ -129,7 +146,7 @@ export async function loadVoiceSettings(): Promise<STTSettings | null> {
   if (!raw) return null;
 
   try {
-    return mergeVoiceSettings(JSON.parse(raw) as Partial<STTSettings>);
+    return normalizeVoiceSettings(JSON.parse(raw));
   } catch (parseErr) {
     console.warn('[dnd-ref] Failed to parse voice settings:', parseErr);
     return null;

--- a/src/storage/app-data.ts
+++ b/src/storage/app-data.ts
@@ -87,15 +87,18 @@ export function createDefaultDataSourceSettings(): DataSourcesSettings {
 }
 
 export function mergeDataSourceSettings(
-  settings: Partial<DataSourcesSettings> | null = {},
+  settings?: Partial<DataSourcesSettings> | null,
 ): DataSourcesSettings {
   const patch = settings ?? {};
+  const defaultSettings = createDefaultDataSourceSettings();
+  const srdSources = Array.isArray(patch.srdSources)
+    ? [...patch.srdSources]
+    : defaultSettings.srdSources;
+
   return {
-    ...createDefaultDataSourceSettings(),
+    ...defaultSettings,
     ...patch,
-    srdSources: Array.isArray(patch.srdSources)
-      ? [...patch.srdSources]
-      : [...DEFAULT_DATA_SOURCES_SETTINGS.srdSources],
+    srdSources,
   };
 }
 
@@ -119,12 +122,16 @@ export async function loadDataSourceSettings(): Promise<DataSourcesSettings | nu
 }
 
 export async function saveDataSourceSettings(settings: DataSourcesSettings): Promise<boolean> {
-  const saved = await setAppDataItem(DATA_SOURCES_KEY, JSON.stringify(settings)).catch((e) => {
+  const serializedSettings = JSON.stringify(settings);
+
+  try {
+    const saved = await setAppDataItem(DATA_SOURCES_KEY, serializedSettings);
+    if (saved) allowAppDataCacheWrites();
+    return saved;
+  } catch (e) {
     console.warn('[dnd-ref] Failed to save data source settings:', e);
     return false;
-  });
-  if (saved) allowAppDataCacheWrites();
-  return saved;
+  }
 }
 
 export async function getAppDataItem(key: string, token = createAppDataWriteToken()): Promise<string | null> {

--- a/src/storage/app-data.ts
+++ b/src/storage/app-data.ts
@@ -144,10 +144,7 @@ export async function getUploadedFiles(): Promise<UploadedFile[]> {
 }
 
 export async function addUploadedFile(name: string, content: string): Promise<boolean> {
-  return mutateUploadedFiles((uploads) => {
-    const id = `upload-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-    return [...uploads, { id, name, content }];
-  });
+  return mutateUploadedFiles((uploads) => [...uploads, createUploadedFile(name, content)]);
 }
 
 export async function removeUploadedFile(id: string): Promise<boolean> {
@@ -158,12 +155,21 @@ export async function waitForUploadedFileMutations(): Promise<void> {
   await uploadMutationQueue.catch(() => undefined);
 }
 
+function createUploadedFile(name: string, content: string): UploadedFile {
+  return {
+    id: `upload-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    name,
+    content,
+  };
+}
+
 function isUploadedFile(value: unknown): value is UploadedFile {
-  return !!value &&
-    typeof value === 'object' &&
-    typeof (value as UploadedFile).id === 'string' &&
-    typeof (value as UploadedFile).name === 'string' &&
-    typeof (value as UploadedFile).content === 'string';
+  if (!value || typeof value !== 'object') return false;
+
+  const file = value as Record<string, unknown>;
+  return typeof file.id === 'string' &&
+    typeof file.name === 'string' &&
+    typeof file.content === 'string';
 }
 
 async function readUploadedFiles(token: number): Promise<UploadedFile[]> {
@@ -184,9 +190,11 @@ function mutateUploadedFiles(mutator: (uploads: UploadedFile[]) => UploadedFile[
     .catch(() => undefined)
     .then(async () => {
       if (!canPersistAppData(token)) return false;
-      const uploads = await readUploadedFiles(token);
+      const currentUploads = await readUploadedFiles(token);
       if (!canPersistAppData(token)) return false;
-      return setAppDataItem(UPLOADS_KEY, JSON.stringify(mutator(uploads)), { token });
+
+      const nextUploads = mutator(currentUploads);
+      return setAppDataItem(UPLOADS_KEY, JSON.stringify(nextUploads), { token });
     });
 
   uploadMutationQueue = operation.catch(() => undefined);
@@ -216,15 +224,16 @@ export async function setAppDataItem(
   value: string,
   options: { cache?: boolean; token?: number } = {},
 ): Promise<boolean> {
-  const token = options.token ?? createAppDataWriteToken();
+  const { cache = false, token = createAppDataWriteToken() } = options;
   const operation = appDataWriteQueue
     .catch(() => undefined)
     .then(async () => {
-      const canPersist = options.cache ? canPersistAppDataCache : canPersistAppData;
+      const canPersist = cache ? canPersistAppDataCache : canPersistAppData;
       if (!canPersist(token)) return false;
+
       await AsyncStorage.setItem(key, value);
       const saved = canPersist(token);
-      if (saved && !options.cache) allowAppDataCacheWrites();
+      if (saved && !cache) allowAppDataCacheWrites();
       return saved;
     });
 

--- a/src/storage/app-data.ts
+++ b/src/storage/app-data.ts
@@ -1,323 +1,52 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+export {
+  APP_STORAGE_KEYS,
+  allowAppDataCacheWrites,
+  beginAppDataReset,
+  canPersistAppData,
+  canPersistAppDataCache,
+  clearStoredAppData,
+  createAppDataCacheSession,
+  createAppDataWriteToken,
+  finishAppDataReset,
+  getAppDataItem,
+  getStoredAppDataKeys,
+  isAppDataWriteTokenCurrent,
+  isAppStorageKey,
+  setAppDataItem,
+  waitForAppDataWrites,
+  type AppDataCacheSession,
+} from './app-data-core';
+export {
+  DEFAULT_DATA_SOURCES_SETTINGS,
+  createDefaultDataSourceSettings,
+  createDefaultVoiceSettings,
+  loadDataSourceSettings,
+  loadVoiceSettings,
+  mergeDataSourceSettings,
+  mergeVoiceSettings,
+  saveDataSourceSettings,
+  saveVoiceSettings,
+  type DataSourcesSettings,
+} from './app-data-settings';
+export {
+  addUploadedFile,
+  getUploadedFiles,
+  removeUploadedFile,
+  waitForUploadedFileMutations,
+  type UploadedFile,
+} from './app-data-uploads';
 
-import { DEFAULT_STT_SETTINGS, STT_SETTINGS_KEY, type STTSettings } from '../stt';
 import {
-  CARD_SIZE_KEY,
-  COLOR_SCHEME_KEY,
-  DATA_SOURCES_KEY,
-  SRD_CACHE_KEY_PREFIX,
-  UPLOADS_KEY,
-} from './keys';
-
-const APP_STORAGE_PREFIXES = ['dndref:', '@dnd-ref/'];
-const INVALID_APP_DATA_TOKEN = -1;
-
-export interface UploadedFile {
-  id: string;
-  name: string;
-  content: string;
-}
-
-export interface DataSourcesSettings {
-  srdEnabled: boolean;
-  srdSources: string[];
-  kankaToken: string;
-  kankaCampaignId: string;
-  homebreweryUrl: string;
-  notionToken: string;
-  notionPageIds: string;
-  googleDocsUrl: string;
-  aiApiKey: string;
-}
-
-export const DEFAULT_DATA_SOURCES_SETTINGS: DataSourcesSettings = {
-  srdEnabled: true,
-  srdSources: ['wotc-srd'],
-  kankaToken: '',
-  kankaCampaignId: '',
-  homebreweryUrl: '',
-  notionToken: '',
-  notionPageIds: '',
-  googleDocsUrl: '',
-  aiApiKey: '',
-};
-
-let appDataResetGeneration = 0;
-let appDataResetActive = false;
-let cacheWritesBlockedForGeneration: number | null = null;
-let appDataWriteQueue: Promise<unknown> = Promise.resolve();
-let uploadMutationQueue: Promise<unknown> = Promise.resolve();
-
-export const APP_STORAGE_KEYS = [
-  DATA_SOURCES_KEY,
-  UPLOADS_KEY,
-  STT_SETTINGS_KEY,
-  CARD_SIZE_KEY,
-  COLOR_SCHEME_KEY,
-];
-
-export function isAppStorageKey(key: string): boolean {
-  return (
-    APP_STORAGE_KEYS.includes(key) ||
-    key.startsWith(SRD_CACHE_KEY_PREFIX) ||
-    APP_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
-  );
-}
-
-export function createAppDataWriteToken(): number {
-  return appDataResetActive ? INVALID_APP_DATA_TOKEN : appDataResetGeneration;
-}
-
-export function isAppDataWriteTokenCurrent(token: number): boolean {
-  return token !== INVALID_APP_DATA_TOKEN &&
-    token === appDataResetGeneration &&
-    !appDataResetActive;
-}
-
-export function canPersistAppData(token: number): boolean {
-  return isAppDataWriteTokenCurrent(token);
-}
-
-export function canPersistAppDataCache(token: number): boolean {
-  return canPersistAppData(token) && cacheWritesBlockedForGeneration !== token;
-}
-
-export function allowAppDataCacheWrites(): void {
-  cacheWritesBlockedForGeneration = null;
-}
-
-export function createDefaultDataSourceSettings(): DataSourcesSettings {
-  return {
-    ...DEFAULT_DATA_SOURCES_SETTINGS,
-    srdSources: [...DEFAULT_DATA_SOURCES_SETTINGS.srdSources],
-  };
-}
-
-export function mergeDataSourceSettings(
-  settings?: Partial<DataSourcesSettings> | null,
-): DataSourcesSettings {
-  const patch = settings ?? {};
-  const defaultSettings = createDefaultDataSourceSettings();
-  const srdSources = Array.isArray(patch.srdSources)
-    ? [...patch.srdSources]
-    : defaultSettings.srdSources;
-
-  return {
-    ...defaultSettings,
-    ...patch,
-    srdSources,
-  };
-}
-
-type VoiceSettingsPatch = Partial<Record<keyof STTSettings, unknown>>;
-
-function isVoiceSettingsPatch(value: unknown): value is VoiceSettingsPatch {
-  return value !== null && typeof value === 'object';
-}
-
-function isVoiceProvider(value: unknown): value is STTSettings['provider'] {
-  return value === 'deepgram' || value === 'web-speech';
-}
-
-export function createDefaultVoiceSettings(): STTSettings {
-  return { ...DEFAULT_STT_SETTINGS };
-}
-
-function normalizeVoiceSettings(settings: unknown): STTSettings {
-  const patch = isVoiceSettingsPatch(settings) ? settings : {};
-  const defaultSettings = createDefaultVoiceSettings();
-
-  const provider = isVoiceProvider(patch.provider)
-    ? patch.provider
-    : defaultSettings.provider;
-  const deepgramApiKey = typeof patch.deepgramApiKey === 'string'
-    ? patch.deepgramApiKey
-    : defaultSettings.deepgramApiKey;
-
-  return { provider, deepgramApiKey };
-}
-
-export function mergeVoiceSettings(settings?: Partial<STTSettings> | null): STTSettings {
-  return normalizeVoiceSettings(settings);
-}
-
-export async function loadVoiceSettings(): Promise<STTSettings | null> {
-  let raw: string | null;
-  try {
-    raw = await getAppDataItem(STT_SETTINGS_KEY);
-  } catch (e) {
-    console.warn('[dnd-ref] Failed to load voice settings:', e);
-    return null;
-  }
-
-  if (!raw) return null;
-
-  try {
-    return normalizeVoiceSettings(JSON.parse(raw));
-  } catch (parseErr) {
-    console.warn('[dnd-ref] Failed to parse voice settings:', parseErr);
-    return null;
-  }
-}
-
-export async function saveVoiceSettings(settings: STTSettings): Promise<boolean> {
-  const serializedSettings = JSON.stringify(mergeVoiceSettings(settings));
-
-  try {
-    return await setAppDataItem(STT_SETTINGS_KEY, serializedSettings);
-  } catch (e) {
-    console.warn('[dnd-ref] Failed to save voice settings:', e);
-    return false;
-  }
-}
-
-export async function loadDataSourceSettings(): Promise<DataSourcesSettings | null> {
-  let raw: string | null;
-  try {
-    raw = await getAppDataItem(DATA_SOURCES_KEY);
-  } catch (e) {
-    console.warn('[dnd-ref] Failed to load data source settings:', e);
-    return null;
-  }
-
-  if (!raw) return null;
-
-  try {
-    return mergeDataSourceSettings(JSON.parse(raw) as Partial<DataSourcesSettings>);
-  } catch (parseErr) {
-    console.warn('[dnd-ref] Failed to parse data source settings:', parseErr);
-    return null;
-  }
-}
-
-export async function saveDataSourceSettings(settings: DataSourcesSettings): Promise<boolean> {
-  const serializedSettings = JSON.stringify(settings);
-
-  try {
-    return await setAppDataItem(DATA_SOURCES_KEY, serializedSettings);
-  } catch (e) {
-    console.warn('[dnd-ref] Failed to save data source settings:', e);
-    return false;
-  }
-}
-
-export async function getUploadedFiles(): Promise<UploadedFile[]> {
-  return readUploadedFiles(createAppDataWriteToken());
-}
-
-export async function addUploadedFile(name: string, content: string): Promise<boolean> {
-  return mutateUploadedFiles((uploads) => [...uploads, createUploadedFile(name, content)]);
-}
-
-export async function removeUploadedFile(id: string): Promise<boolean> {
-  return mutateUploadedFiles((uploads) => uploads.filter((u) => u.id !== id));
-}
-
-export async function waitForUploadedFileMutations(): Promise<void> {
-  await uploadMutationQueue.catch(() => undefined);
-}
-
-function createUploadedFile(name: string, content: string): UploadedFile {
-  return {
-    id: `upload-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-    name,
-    content,
-  };
-}
-
-function isUploadedFile(value: unknown): value is UploadedFile {
-  if (!value || typeof value !== 'object') return false;
-
-  const file = value as Record<string, unknown>;
-  return typeof file.id === 'string' &&
-    typeof file.name === 'string' &&
-    typeof file.content === 'string';
-}
-
-async function readUploadedFiles(token: number): Promise<UploadedFile[]> {
-  try {
-    const raw = await getAppDataItem(UPLOADS_KEY, token);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? parsed.filter(isUploadedFile) : [];
-  } catch (e) {
-    console.warn('[dnd-ref] Failed to read uploads from storage:', e);
-    return [];
-  }
-}
-
-function mutateUploadedFiles(mutator: (uploads: UploadedFile[]) => UploadedFile[]): Promise<boolean> {
-  const token = createAppDataWriteToken();
-  const operation = uploadMutationQueue
-    .catch(() => undefined)
-    .then(async () => {
-      if (!canPersistAppData(token)) return false;
-      const currentUploads = await readUploadedFiles(token);
-      if (!canPersistAppData(token)) return false;
-
-      const nextUploads = mutator(currentUploads);
-      return setAppDataItem(UPLOADS_KEY, JSON.stringify(nextUploads), { token });
-    });
-
-  uploadMutationQueue = operation.catch(() => undefined);
-  return operation;
-}
-
-export interface AppDataCacheSession {
-  getItem: (key: string) => Promise<string | null>;
-  setItem: (key: string, value: string) => Promise<boolean>;
-}
-
-export function createAppDataCacheSession(): AppDataCacheSession {
-  const token = createAppDataWriteToken();
-  return {
-    getItem: (key) => getAppDataItem(key, token),
-    setItem: (key, value) => setAppDataItem(key, value, { cache: true, token }),
-  };
-}
-
-export async function getAppDataItem(key: string, token = createAppDataWriteToken()): Promise<string | null> {
-  const value = await AsyncStorage.getItem(key);
-  return isAppDataWriteTokenCurrent(token) ? value : null;
-}
-
-export async function setAppDataItem(
-  key: string,
-  value: string,
-  options: { cache?: boolean; token?: number } = {},
-): Promise<boolean> {
-  const { cache = false, token = createAppDataWriteToken() } = options;
-  const operation = appDataWriteQueue
-    .catch(() => undefined)
-    .then(async () => {
-      const canPersist = cache ? canPersistAppDataCache : canPersistAppData;
-      if (!canPersist(token)) return false;
-
-      await AsyncStorage.setItem(key, value);
-      const saved = canPersist(token);
-      if (saved && !cache) allowAppDataCacheWrites();
-      return saved;
-    });
-
-  appDataWriteQueue = operation.catch(() => undefined);
-  return operation;
-}
-
-export async function waitForAppDataWrites(): Promise<void> {
-  await appDataWriteQueue.catch(() => undefined);
-}
-
-export function beginAppDataReset(): number {
-  appDataResetGeneration += 1;
-  appDataResetActive = true;
-  return appDataResetGeneration;
-}
-
-export function finishAppDataReset(generation: number): void {
-  if (generation !== appDataResetGeneration) return;
-  appDataResetActive = false;
-  cacheWritesBlockedForGeneration = generation;
-}
+  beginAppDataReset,
+  clearStoredAppData,
+  finishAppDataReset,
+  resetAppDataCoreControlsForTests,
+  waitForAppDataWrites,
+} from './app-data-core';
+import {
+  resetUploadedFileMutationQueueForTests,
+  waitForUploadedFileMutations,
+} from './app-data-uploads';
 
 export async function resetStoredAppData(options: {
   beforeClear?: () => Promise<void>;
@@ -333,23 +62,7 @@ export async function resetStoredAppData(options: {
   }
 }
 
-export async function getStoredAppDataKeys(): Promise<string[]> {
-  const keys = await AsyncStorage.getAllKeys();
-  return Array.from(new Set(keys.filter(isAppStorageKey)));
-}
-
-export async function clearStoredAppData(): Promise<string[]> {
-  const keys = await getStoredAppDataKeys();
-  if (keys.length > 0) {
-    await AsyncStorage.multiRemove(keys);
-  }
-  return keys;
-}
-
 export function resetAppDataControlsForTests(): void {
-  appDataResetGeneration = 0;
-  appDataResetActive = false;
-  cacheWritesBlockedForGeneration = null;
-  appDataWriteQueue = Promise.resolve();
-  uploadMutationQueue = Promise.resolve();
+  resetAppDataCoreControlsForTests();
+  resetUploadedFileMutationQueueForTests();
 }

--- a/src/stt/build-provider.test.ts
+++ b/src/stt/build-provider.test.ts
@@ -2,10 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const storage = vi.hoisted(() => new Map<string, string>());
 const platform = vi.hoisted(() => ({ OS: 'web' }));
+
+type MockProviderInstance = {
+  emitError(error: string): void;
+  emitTranscript(text: string): void;
+};
+
 const sttMocks = vi.hoisted(() => ({
-  deepgramInstances: [] as any[],
+  deepgramInstances: [] as MockProviderInstance[],
   deepgramStartError: null as Error | null,
-  webSpeechInstances: [] as any[],
+  webSpeechInstances: [] as MockProviderInstance[],
   webSpeechStartError: null as Error | null,
 }));
 
@@ -18,7 +24,7 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
   },
 }));
 vi.mock('react-native', () => ({ Platform: platform }));
-vi.mock('../stt/deepgram', () => ({
+vi.mock('./deepgram', () => ({
   DeepgramProvider: class {
     readonly name = 'Deepgram';
 
@@ -30,18 +36,19 @@ vi.mock('../stt/deepgram', () => ({
       sttMocks.deepgramInstances.push(this);
     }
 
-    async start() {
+    async start(): Promise<void> {
       if (sttMocks.deepgramStartError) throw sttMocks.deepgramStartError;
     }
 
-    pause() {}
-    resume() {}
-    stop() {}
-    emitTranscript(text: string) { this.onTranscript(text); }
-    emitError(error: string) { this.onError(error); }
+    pause(): void {}
+    resume(): void {}
+    stop(): void {}
+
+    emitTranscript(text: string): void { this.onTranscript(text); }
+    emitError(error: string): void { this.onError(error); }
   },
 }));
-vi.mock('../stt/web-speech', () => ({
+vi.mock('./web-speech', () => ({
   WebSpeechProvider: class {
     readonly name = 'Web Speech';
 
@@ -52,15 +59,16 @@ vi.mock('../stt/web-speech', () => ({
       sttMocks.webSpeechInstances.push(this);
     }
 
-    async start() {
+    async start(): Promise<void> {
       if (sttMocks.webSpeechStartError) throw sttMocks.webSpeechStartError;
     }
 
-    pause() {}
-    resume() {}
-    stop() {}
-    emitTranscript(text: string) { this.onTranscript(text); }
-    emitError(error: string) { this.onError(error); }
+    pause(): void {}
+    resume(): void {}
+    stop(): void {}
+
+    emitTranscript(text: string): void { this.onTranscript(text); }
+    emitError(error: string): void { this.onError(error); }
   },
 }));
 

--- a/src/stt/build-provider.test.ts
+++ b/src/stt/build-provider.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const storage = vi.hoisted(() => new Map<string, string>());
 const platform = vi.hoisted(() => ({ OS: 'web' }));
+const sttMocks = vi.hoisted(() => ({
+  deepgramInstances: [] as any[],
+  deepgramStartError: null as Error | null,
+  webSpeechInstances: [] as any[],
+  webSpeechStartError: null as Error | null,
+}));
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
   default: {
@@ -15,20 +21,46 @@ vi.mock('react-native', () => ({ Platform: platform }));
 vi.mock('../stt/deepgram', () => ({
   DeepgramProvider: class {
     readonly name = 'Deepgram';
-    constructor(readonly apiKey: string) {}
-    async start() {}
+
+    constructor(
+      readonly apiKey: string,
+      readonly onTranscript: (text: string) => void,
+      readonly onError: (error: string) => void,
+    ) {
+      sttMocks.deepgramInstances.push(this);
+    }
+
+    async start() {
+      if (sttMocks.deepgramStartError) throw sttMocks.deepgramStartError;
+    }
+
     pause() {}
     resume() {}
     stop() {}
+    emitTranscript(text: string) { this.onTranscript(text); }
+    emitError(error: string) { this.onError(error); }
   },
 }));
 vi.mock('../stt/web-speech', () => ({
   WebSpeechProvider: class {
     readonly name = 'Web Speech';
-    async start() {}
+
+    constructor(
+      readonly onTranscript: (text: string) => void,
+      readonly onError: (error: string) => void,
+    ) {
+      sttMocks.webSpeechInstances.push(this);
+    }
+
+    async start() {
+      if (sttMocks.webSpeechStartError) throw sttMocks.webSpeechStartError;
+    }
+
     pause() {}
     resume() {}
     stop() {}
+    emitTranscript(text: string) { this.onTranscript(text); }
+    emitError(error: string) { this.onError(error); }
   },
 }));
 
@@ -39,6 +71,10 @@ describe('STT provider settings', () => {
   beforeEach(() => {
     storage.clear();
     platform.OS = 'web';
+    sttMocks.deepgramInstances.length = 0;
+    sttMocks.deepgramStartError = null;
+    sttMocks.webSpeechInstances.length = 0;
+    sttMocks.webSpeechStartError = null;
     resetAppDataControlsForTests();
     vi.clearAllMocks();
   });
@@ -55,5 +91,33 @@ describe('STT provider settings', () => {
 
     expect(loadedSettings).toEqual(savedSettings);
     expect(provider.name).toBe('Deepgram');
+  });
+
+  it('wraps Web Speech so stopped capture events do not reach session callbacks', async () => {
+    const onTranscript = vi.fn();
+    const onError = vi.fn();
+    const provider = buildProvider({ provider: 'web-speech', deepgramApiKey: '' }, onTranscript, onError);
+
+    await provider.start();
+    sttMocks.webSpeechInstances[0].emitTranscript('active speech');
+    await provider.stop();
+    sttMocks.webSpeechInstances[0].emitTranscript('late speech');
+    sttMocks.webSpeechInstances[0].emitError('late error');
+
+    expect(onTranscript).toHaveBeenCalledTimes(1);
+    expect(onTranscript).toHaveBeenCalledWith('active speech');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('still propagates Web Speech and Deepgram startup failures', async () => {
+    sttMocks.webSpeechStartError = new Error('browser mic denied');
+    await expect(
+      buildProvider({ provider: 'web-speech', deepgramApiKey: '' }, vi.fn(), vi.fn()).start(),
+    ).rejects.toThrow('browser mic denied');
+
+    sttMocks.deepgramStartError = new Error('deepgram rejected key');
+    await expect(
+      buildProvider({ provider: 'deepgram', deepgramApiKey: 'bad-key' }, vi.fn(), vi.fn()).start(),
+    ).rejects.toThrow('deepgram rejected key');
   });
 });

--- a/src/stt/build-provider.test.ts
+++ b/src/stt/build-provider.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storage = vi.hoisted(() => new Map<string, string>());
+const platform = vi.hoisted(() => ({ OS: 'web' }));
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(async (key: string) => storage.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storage.set(key, value);
+    }),
+  },
+}));
+vi.mock('react-native', () => ({ Platform: platform }));
+vi.mock('../stt/deepgram', () => ({
+  DeepgramProvider: class {
+    readonly name = 'Deepgram';
+    constructor(readonly apiKey: string) {}
+    async start() {}
+    pause() {}
+    resume() {}
+    stop() {}
+  },
+}));
+vi.mock('../stt/web-speech', () => ({
+  WebSpeechProvider: class {
+    readonly name = 'Web Speech';
+    async start() {}
+    pause() {}
+    resume() {}
+    stop() {}
+  },
+}));
+
+import { buildProvider, loadSettings } from './build-provider';
+import { resetAppDataControlsForTests, saveVoiceSettings } from '../storage/app-data';
+
+describe('STT provider settings', () => {
+  beforeEach(() => {
+    storage.clear();
+    platform.OS = 'web';
+    resetAppDataControlsForTests();
+    vi.clearAllMocks();
+  });
+
+  it('uses voice settings saved through local app data for the next provider selection', async () => {
+    const savedSettings = {
+      provider: 'deepgram' as const,
+      deepgramApiKey: 'saved-session-key',
+    };
+
+    await saveVoiceSettings(savedSettings);
+    const loadedSettings = await loadSettings();
+    const provider = buildProvider(loadedSettings, vi.fn(), vi.fn());
+
+    expect(loadedSettings).toEqual(savedSettings);
+    expect(provider.name).toBe('Deepgram');
+  });
+});

--- a/src/stt/build-provider.ts
+++ b/src/stt/build-provider.ts
@@ -1,10 +1,11 @@
 import { Platform } from 'react-native';
 
+import { DeepgramProvider } from './deepgram';
+import { createLateEventSafeSTTProvider, type STTProviderFactory } from './lifecycle-safe-provider';
+import { WebSpeechProvider } from './web-speech';
 import { createDefaultVoiceSettings, loadVoiceSettings } from '../storage/app-data';
-import { DeepgramProvider } from '../stt/deepgram';
-import { STTProvider, STTSettings } from '../stt/index';
-import { createLateEventSafeSTTProvider } from '../stt/lifecycle-safe-provider';
-import { WebSpeechProvider } from '../stt/web-speech';
+
+import type { STTProvider, STTSettings } from './index';
 
 export async function loadSettings(): Promise<STTSettings> {
   return (await loadVoiceSettings()) ?? createDefaultVoiceSettings();
@@ -15,23 +16,26 @@ export function buildProvider(
   onTranscript: (text: string) => void,
   onError: (error: string) => void,
 ): STTProvider {
-  if (Platform.OS !== 'web') {
-    return createLateEventSafeSTTProvider(
-      (safeTranscript, safeError) => new DeepgramProvider(settings.deepgramApiKey, safeTranscript, safeError),
-      onTranscript,
-      onError,
-    );
-  }
-  if (settings.provider === 'deepgram' && settings.deepgramApiKey) {
-    return createLateEventSafeSTTProvider(
-      (safeTranscript, safeError) => new DeepgramProvider(settings.deepgramApiKey, safeTranscript, safeError),
-      onTranscript,
-      onError,
-    );
-  }
   return createLateEventSafeSTTProvider(
-    (safeTranscript, safeError) => new WebSpeechProvider(safeTranscript, safeError),
+    createProviderFactory(settings),
     onTranscript,
     onError,
   );
+}
+
+function createProviderFactory(settings: STTSettings): STTProviderFactory {
+  if (shouldUseDeepgram(settings)) {
+    return (safeTranscript, safeError) => new DeepgramProvider(
+      settings.deepgramApiKey,
+      safeTranscript,
+      safeError,
+    );
+  }
+
+  return (safeTranscript, safeError) => new WebSpeechProvider(safeTranscript, safeError);
+}
+
+function shouldUseDeepgram(settings: STTSettings): boolean {
+  return Platform.OS !== 'web'
+    || (settings.provider === 'deepgram' && Boolean(settings.deepgramApiKey));
 }

--- a/src/stt/build-provider.ts
+++ b/src/stt/build-provider.ts
@@ -1,24 +1,12 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 
+import { createDefaultVoiceSettings, loadVoiceSettings } from '../storage/app-data';
 import { DeepgramProvider } from '../stt/deepgram';
-import { DEFAULT_STT_SETTINGS, STT_SETTINGS_KEY, STTProvider, STTSettings } from '../stt/index';
+import { STTProvider, STTSettings } from '../stt/index';
 import { WebSpeechProvider } from '../stt/web-speech';
 
 export async function loadSettings(): Promise<STTSettings> {
-  try {
-    const raw = await AsyncStorage.getItem(STT_SETTINGS_KEY);
-    if (raw) {
-      try {
-        return { ...DEFAULT_STT_SETTINGS, ...(JSON.parse(raw) as Partial<STTSettings>) };
-      } catch (parseErr) {
-        console.warn('[dnd-ref] Failed to parse STT settings, using defaults:', parseErr);
-      }
-    }
-  } catch (e) {
-    console.warn('[dnd-ref] Failed to load STT settings, using defaults:', e);
-  }
-  return DEFAULT_STT_SETTINGS;
+  return (await loadVoiceSettings()) ?? createDefaultVoiceSettings();
 }
 
 export function buildProvider(

--- a/src/stt/build-provider.ts
+++ b/src/stt/build-provider.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import { createDefaultVoiceSettings, loadVoiceSettings } from '../storage/app-data';
 import { DeepgramProvider } from '../stt/deepgram';
 import { STTProvider, STTSettings } from '../stt/index';
+import { createLateEventSafeSTTProvider } from '../stt/lifecycle-safe-provider';
 import { WebSpeechProvider } from '../stt/web-speech';
 
 export async function loadSettings(): Promise<STTSettings> {
@@ -15,10 +16,22 @@ export function buildProvider(
   onError: (error: string) => void,
 ): STTProvider {
   if (Platform.OS !== 'web') {
-    return new DeepgramProvider(settings.deepgramApiKey, onTranscript, onError);
+    return createLateEventSafeSTTProvider(
+      (safeTranscript, safeError) => new DeepgramProvider(settings.deepgramApiKey, safeTranscript, safeError),
+      onTranscript,
+      onError,
+    );
   }
   if (settings.provider === 'deepgram' && settings.deepgramApiKey) {
-    return new DeepgramProvider(settings.deepgramApiKey, onTranscript, onError);
+    return createLateEventSafeSTTProvider(
+      (safeTranscript, safeError) => new DeepgramProvider(settings.deepgramApiKey, safeTranscript, safeError),
+      onTranscript,
+      onError,
+    );
   }
-  return new WebSpeechProvider(onTranscript, onError);
+  return createLateEventSafeSTTProvider(
+    (safeTranscript, safeError) => new WebSpeechProvider(safeTranscript, safeError),
+    onTranscript,
+    onError,
+  );
 }

--- a/src/stt/deepgram-browser.test.ts
+++ b/src/stt/deepgram-browser.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DeepgramBrowserCaptureAdapter } from './deepgram-browser';
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+const originalMediaRecorder = Object.getOwnPropertyDescriptor(globalThis, 'MediaRecorder');
+const originalWebSocket = Object.getOwnPropertyDescriptor(globalThis, 'WebSocket');
+
+type MockTrack = { stop: () => void };
+type MockStream = { getTracks: () => MockTrack[] };
+
+type BrowserCaptureMocks = {
+  getUserMedia: ReturnType<typeof vi.fn>;
+  recorders: MockMediaRecorder[];
+  sockets: MockWebSocket[];
+  stream: MockStream;
+  trackStop: ReturnType<typeof vi.fn>;
+};
+
+class MockMediaRecorder {
+  static isTypeSupported(): boolean { return true; }
+
+  ondataavailable: ((event: { data: { size: number } }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  startMs: number | null = null;
+  state = 'inactive';
+  stopCalls = 0;
+
+  constructor(
+    readonly stream: MockStream,
+    readonly options?: unknown,
+  ) {
+    installedBrowserMocks?.recorders.push(this);
+  }
+
+  start(ms: number): void {
+    this.state = 'recording';
+    this.startMs = ms;
+  }
+
+  pause(): void { this.state = 'paused'; }
+  resume(): void { this.state = 'recording'; }
+
+  stop(): void {
+    this.stopCalls += 1;
+    this.state = 'inactive';
+  }
+
+  emitChunk(data: { size: number }): void {
+    this.ondataavailable?.({ data });
+  }
+}
+
+class MockWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  closeCalls = 0;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onopen: (() => void) | null = null;
+  readyState = 0;
+  sent: unknown[] = [];
+
+  constructor(
+    readonly url: string,
+    readonly protocols: string[],
+  ) {
+    installedBrowserMocks?.sockets.push(this);
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: 1000 } as CloseEvent);
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  send(data: unknown): void {
+    this.sent.push(data);
+  }
+
+  receive(data: string): void {
+    this.onmessage?.({ data });
+  }
+}
+
+let installedBrowserMocks: BrowserCaptureMocks | null = null;
+
+function flush(): Promise<void> {
+  return Promise.resolve().then(() => undefined);
+}
+
+function restoreGlobalProperty(key: string, descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+  else Reflect.deleteProperty(globalThis, key);
+}
+
+function installBrowserCapture(getUserMedia?: ReturnType<typeof vi.fn>): BrowserCaptureMocks {
+  const recorders: MockMediaRecorder[] = [];
+  const sockets: MockWebSocket[] = [];
+  const trackStop = vi.fn();
+  const stream: MockStream = { getTracks: () => [{ stop: trackStop }] };
+  const mediaGetter = getUserMedia ?? vi.fn(async () => stream);
+  const mocks = { getUserMedia: mediaGetter, recorders, sockets, stream, trackStop };
+
+  installedBrowserMocks = mocks;
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { mediaDevices: { getUserMedia: mediaGetter } },
+  });
+  (globalThis as any).MediaRecorder = MockMediaRecorder;
+  (globalThis as any).WebSocket = MockWebSocket;
+  return mocks;
+}
+
+afterEach(() => {
+  installedBrowserMocks = null;
+  restoreGlobalProperty('navigator', originalNavigator);
+  restoreGlobalProperty('MediaRecorder', originalMediaRecorder);
+  restoreGlobalProperty('WebSocket', originalWebSocket);
+  vi.clearAllMocks();
+});
+
+describe('Deepgram browser capture adapter', () => {
+  it('streams browser microphone chunks over Deepgram websocket and cleans up resources', async () => {
+    const { recorders, sockets, trackStop } = installBrowserCapture();
+    const onTranscript = vi.fn();
+    const provider = new DeepgramBrowserCaptureAdapter('browser-key', onTranscript, vi.fn());
+
+    const startPromise = provider.start();
+    await flush();
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].url).toContain('wss://api.deepgram.com/v1/listen?model=nova-2');
+    expect(sockets[0].protocols).toEqual(['token', 'browser-key']);
+
+    sockets[0].open();
+    await startPromise;
+
+    expect(recorders).toHaveLength(1);
+    expect(recorders[0].startMs).toBe(250);
+
+    const chunk = { size: 42 };
+    recorders[0].emitChunk(chunk);
+    sockets[0].receive(JSON.stringify({
+      type: 'Results',
+      is_final: true,
+      channel: { alternatives: [{ transcript: 'Strahd arrives' }] },
+    }));
+
+    expect(sockets[0].sent).toEqual([chunk]);
+    expect(onTranscript).toHaveBeenCalledWith('Strahd arrives');
+
+    await provider.stop();
+
+    expect(recorders[0].stopCalls).toBe(1);
+    expect(sockets[0].closeCalls).toBe(1);
+    expect(trackStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up web mic stream when stopped before Deepgram websocket opens', async () => {
+    const { sockets, trackStop } = installBrowserCapture();
+    const provider = new DeepgramBrowserCaptureAdapter('key', vi.fn(), vi.fn());
+
+    const startPromise = provider.start();
+    await flush();
+
+    const rejectedStart = expect(startPromise).rejects.toThrow('Deepgram connection closed');
+    provider.stop();
+    await rejectedStart;
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].closeCalls).toBe(1);
+    expect(trackStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up web mic stream when stopped while getUserMedia is pending', async () => {
+    const trackStop = vi.fn();
+    const stream: MockStream = { getTracks: () => [{ stop: trackStop }] };
+    let resolveStream!: (value: MockStream) => void;
+    const getUserMedia = vi.fn(() => new Promise<MockStream>((resolve) => { resolveStream = resolve; }));
+    const { sockets } = installBrowserCapture(getUserMedia);
+    const provider = new DeepgramBrowserCaptureAdapter('key', vi.fn(), vi.fn());
+
+    const startPromise = provider.start();
+    await flush();
+
+    await provider.stop();
+    resolveStream(stream);
+
+    await expect(startPromise).rejects.toThrow('microphone access completed');
+    expect(trackStop).toHaveBeenCalledTimes(1);
+    expect(sockets).toHaveLength(0);
+  });
+});

--- a/src/stt/deepgram-browser.ts
+++ b/src/stt/deepgram-browser.ts
@@ -1,0 +1,173 @@
+import type { STTProvider } from './index';
+
+import {
+  assertDeepgramApiKey,
+  DEEPGRAM_PARAMS,
+  DEEPGRAM_WS_URL,
+  getDeepgramCloseMessage,
+} from './deepgram-shared';
+
+export class DeepgramBrowserCaptureAdapter implements STTProvider {
+  readonly name = 'Deepgram';
+  private active = false;
+  private recorder: MediaRecorder | null = null;
+  private stream: MediaStream | null = null;
+  private ws: WebSocket | null = null;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly onTranscript: (text: string) => void,
+    private readonly onError: (error: string) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    assertDeepgramApiKey(this.apiKey);
+    this.active = true;
+    await this.startBrowserCapture();
+  }
+
+  pause(): void {
+    this.active = false;
+    if (this.recorder?.state === 'recording') this.recorder.pause();
+  }
+
+  async resume(): Promise<void> {
+    this.active = true;
+    if (this.recorder?.state === 'paused' && this.ws?.readyState === WebSocket.OPEN) {
+      this.recorder.resume();
+      return;
+    }
+    this.cleanup();
+    await this.startBrowserCapture();
+  }
+
+  stop(): void {
+    this.active = false;
+    this.cleanup();
+  }
+
+  private getRecorderOptions(): MediaRecorderOptions | undefined {
+    if (typeof MediaRecorder === 'undefined') return undefined;
+    const supportedTypes = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'];
+    const mimeType = supportedTypes.find((type) => MediaRecorder.isTypeSupported(type));
+    return mimeType ? { mimeType } : undefined;
+  }
+
+  private cleanup(): void {
+    const recorder = this.recorder;
+    this.recorder = null;
+    try {
+      if (recorder && recorder.state !== 'inactive') recorder.stop();
+    } catch {}
+
+    const ws = this.ws;
+    this.ws = null;
+    try {
+      if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) ws.close();
+    } catch {}
+
+    this.stream?.getTracks().forEach((track) => track.stop());
+    this.stream = null;
+  }
+
+  private async startBrowserCapture(): Promise<void> {
+    if (!navigator.mediaDevices?.getUserMedia) throw new Error('Microphone capture is not available in this browser.');
+    if (typeof MediaRecorder === 'undefined') throw new Error('Browser audio recording is not available.');
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      throw new Error(`Microphone access denied. ${detail}`);
+    }
+
+    if (!this.active) {
+      stream.getTracks().forEach((track) => track.stop());
+      throw new Error('Recording was stopped before microphone access completed.');
+    }
+    this.stream = stream;
+
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(`${DEEPGRAM_WS_URL}?${DEEPGRAM_PARAMS}`, ['token', this.apiKey]);
+      this.ws = ws;
+      let settled = false;
+
+      const settle = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (err) {
+          this.active = false;
+          this.cleanup();
+          reject(err);
+        } else {
+          resolve();
+        }
+      };
+
+      const timeout = setTimeout(() => {
+        settle(new Error('Deepgram connection timed out. Check your API key and network.'));
+      }, 10000);
+
+      ws.onopen = () => {
+        if (!this.active || !this.stream) {
+          settle(new Error('Recording was stopped before Deepgram connected.'));
+          return;
+        }
+        try {
+          const recorder = new MediaRecorder(this.stream, this.getRecorderOptions());
+          this.recorder = recorder;
+          recorder.ondataavailable = (e) => {
+            if (e.data.size > 0 && this.ws?.readyState === WebSocket.OPEN) this.ws.send(e.data);
+          };
+          recorder.onerror = (event) => {
+            const err = event instanceof ErrorEvent ? event.message : 'Unknown recording error';
+            if (!settled) {
+              settle(new Error(`Mic recording error: ${err}`));
+              return;
+            }
+            if (this.active) this.onError(`Mic recording error: ${err}`);
+          };
+          recorder.start(250);
+          settle();
+        } catch (e) {
+          settle(new Error(`Failed to start browser recorder: ${e instanceof Error ? e.message : String(e)}`));
+        }
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string);
+          if (data.type === 'Results' && data.is_final) {
+            const text: string = data.channel?.alternatives?.[0]?.transcript ?? '';
+            if (text.trim() && this.active) this.onTranscript(text.trim());
+          }
+        } catch (e) {
+          if (this.active) this.onError(`Unexpected Deepgram response: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      };
+
+      ws.onerror = () => {
+        const err = new Error('Deepgram connection error. Check your API key and network.');
+        if (!settled) {
+          settle(err);
+          return;
+        }
+        if (this.active) this.onError(err.message);
+      };
+
+      ws.onclose = (event) => {
+        if (!settled) {
+          settle(new Error(getDeepgramCloseMessage(event)));
+          return;
+        }
+        if (this.active) {
+          this.onError(getDeepgramCloseMessage(event));
+          this.active = false;
+          this.cleanup();
+        }
+      };
+    });
+  }
+}

--- a/src/stt/deepgram-browser.ts
+++ b/src/stt/deepgram-browser.ts
@@ -1,11 +1,16 @@
-import type { STTProvider } from './index';
-
 import {
   assertDeepgramApiKey,
   DEEPGRAM_PARAMS,
   DEEPGRAM_WS_URL,
+  extractDeepgramFinalTranscript,
   getDeepgramCloseMessage,
 } from './deepgram-shared';
+
+import type { STTProvider } from './index';
+
+const BROWSER_RECORDER_MIME_TYPES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'];
+const DEEPGRAM_CONNECTION_TIMEOUT_MS = 10000;
+const RECORDER_TIMESLICE_MS = 250;
 
 export class DeepgramBrowserCaptureAdapter implements STTProvider {
   readonly name = 'Deepgram';
@@ -48,47 +53,60 @@ export class DeepgramBrowserCaptureAdapter implements STTProvider {
 
   private getRecorderOptions(): MediaRecorderOptions | undefined {
     if (typeof MediaRecorder === 'undefined') return undefined;
-    const supportedTypes = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'];
-    const mimeType = supportedTypes.find((type) => MediaRecorder.isTypeSupported(type));
+    const mimeType = BROWSER_RECORDER_MIME_TYPES.find((type) => MediaRecorder.isTypeSupported(type));
     return mimeType ? { mimeType } : undefined;
   }
 
   private cleanup(): void {
+    this.stopRecorder();
+    this.closeSocket();
+    if (this.stream) stopMediaStream(this.stream);
+    this.stream = null;
+  }
+
+  private stopRecorder(): void {
     const recorder = this.recorder;
     this.recorder = null;
     try {
       if (recorder && recorder.state !== 'inactive') recorder.stop();
     } catch {}
+  }
 
+  private closeSocket(): void {
     const ws = this.ws;
     this.ws = null;
     try {
       if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) ws.close();
     } catch {}
-
-    this.stream?.getTracks().forEach((track) => track.stop());
-    this.stream = null;
   }
 
   private async startBrowserCapture(): Promise<void> {
-    if (!navigator.mediaDevices?.getUserMedia) throw new Error('Microphone capture is not available in this browser.');
+    this.stream = await this.openMicrophoneStream();
+    await this.connectDeepgramSocket();
+  }
+
+  private async openMicrophoneStream(): Promise<MediaStream> {
+    const mediaDevices = globalThis.navigator?.mediaDevices;
+    if (!mediaDevices?.getUserMedia) throw new Error('Microphone capture is not available in this browser.');
     if (typeof MediaRecorder === 'undefined') throw new Error('Browser audio recording is not available.');
 
     let stream: MediaStream;
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream = await mediaDevices.getUserMedia({ audio: true });
     } catch (e) {
       const detail = e instanceof Error ? e.message : String(e);
       throw new Error(`Microphone access denied. ${detail}`);
     }
 
     if (!this.active) {
-      stream.getTracks().forEach((track) => track.stop());
+      stopMediaStream(stream);
       throw new Error('Recording was stopped before microphone access completed.');
     }
-    this.stream = stream;
+    return stream;
+  }
 
-    await new Promise<void>((resolve, reject) => {
+  private connectDeepgramSocket(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
       const ws = new WebSocket(`${DEEPGRAM_WS_URL}?${DEEPGRAM_PARAMS}`, ['token', this.apiKey]);
       this.ws = ws;
       let settled = false;
@@ -108,7 +126,7 @@ export class DeepgramBrowserCaptureAdapter implements STTProvider {
 
       const timeout = setTimeout(() => {
         settle(new Error('Deepgram connection timed out. Check your API key and network.'));
-      }, 10000);
+      }, DEEPGRAM_CONNECTION_TIMEOUT_MS);
 
       ws.onopen = () => {
         if (!this.active || !this.stream) {
@@ -129,7 +147,7 @@ export class DeepgramBrowserCaptureAdapter implements STTProvider {
             }
             if (this.active) this.onError(`Mic recording error: ${err}`);
           };
-          recorder.start(250);
+          recorder.start(RECORDER_TIMESLICE_MS);
           settle();
         } catch (e) {
           settle(new Error(`Failed to start browser recorder: ${e instanceof Error ? e.message : String(e)}`));
@@ -137,15 +155,7 @@ export class DeepgramBrowserCaptureAdapter implements STTProvider {
       };
 
       ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data as string);
-          if (data.type === 'Results' && data.is_final) {
-            const text: string = data.channel?.alternatives?.[0]?.transcript ?? '';
-            if (text.trim() && this.active) this.onTranscript(text.trim());
-          }
-        } catch (e) {
-          if (this.active) this.onError(`Unexpected Deepgram response: ${e instanceof Error ? e.message : String(e)}`);
-        }
+        this.handleDeepgramMessage(event.data as string);
       };
 
       ws.onerror = () => {
@@ -158,16 +168,30 @@ export class DeepgramBrowserCaptureAdapter implements STTProvider {
       };
 
       ws.onclose = (event) => {
+        const message = getDeepgramCloseMessage(event);
         if (!settled) {
-          settle(new Error(getDeepgramCloseMessage(event)));
+          settle(new Error(message));
           return;
         }
         if (this.active) {
-          this.onError(getDeepgramCloseMessage(event));
+          this.onError(message);
           this.active = false;
           this.cleanup();
         }
       };
     });
   }
+
+  private handleDeepgramMessage(message: string): void {
+    try {
+      const text = extractDeepgramFinalTranscript(message).trim();
+      if (text && this.active) this.onTranscript(text);
+    } catch (e) {
+      if (this.active) this.onError(`Unexpected Deepgram response: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+}
+
+function stopMediaStream(stream: MediaStream): void {
+  stream.getTracks().forEach((track) => track.stop());
 }

--- a/src/stt/deepgram-native.test.ts
+++ b/src/stt/deepgram-native.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+const nativeState = vi.hoisted(() => {
+  class MockRecording {
+    recordCalls = 0;
+    stopCalls = 0;
+    uri: string;
+
+    constructor() {
+      this.uri = `file:///chunk-${state.recordings.length}.m4a`;
+      state.recordings.push(this);
+    }
+
+    async prepareToRecordAsync(): Promise<void> {
+      if (!state.nextPrepare) return;
+      await state.nextPrepare.promise;
+    }
+
+    record(): void { this.recordCalls += 1; }
+
+    async stop(): Promise<void> { this.stopCalls += 1; }
+
+    release(): void {}
+  }
+
+  const state = {
+    MockRecording,
+    nextPrepare: null as Deferred | null,
+    recordings: [] as MockRecording[],
+  };
+  return state;
+});
+
+const fileSystemMocks = vi.hoisted(() => ({
+  deleteAsync: vi.fn(async () => undefined),
+  uploadAsync: vi.fn(async () => ({
+    body: '{"results":{"channels":[{"alternatives":[{"transcript":""}]}]}}',
+    status: 200,
+  })),
+}));
+
+vi.mock('expo-audio', () => ({
+  RecordingPresets: { HIGH_QUALITY: {} },
+  requestRecordingPermissionsAsync: vi.fn(async () => ({ granted: true })),
+  setAudioModeAsync: vi.fn(async () => undefined),
+}));
+vi.mock('expo-audio/build/AudioModule', () => ({
+  default: { AudioRecorder: nativeState.MockRecording },
+}));
+vi.mock('expo-audio/build/utils/options', () => ({
+  createRecordingOptions: vi.fn((options) => options),
+}));
+vi.mock('expo-file-system/legacy', () => ({
+  default: {},
+  FileSystemUploadType: { BINARY_CONTENT: 'BINARY_CONTENT' },
+  deleteAsync: fileSystemMocks.deleteAsync,
+  uploadAsync: fileSystemMocks.uploadAsync,
+}));
+
+import { DeepgramNativeCaptureAdapter } from './deepgram-native';
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function flushUntil(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 20 && !predicate(); i += 1) await flush();
+}
+
+describe('Deepgram native capture adapter', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    nativeState.nextPrepare = null;
+    nativeState.recordings.length = 0;
+    fileSystemMocks.deleteAsync.mockResolvedValue(undefined);
+    fileSystemMocks.uploadAsync.mockResolvedValue({
+      body: '{"results":{"channels":[{"alternatives":[{"transcript":""}]}]}}',
+      status: 200,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('unloads native recording if stop happens during first chunk startup', async () => {
+    nativeState.nextPrepare = deferred();
+    const onError = vi.fn();
+    const provider = new DeepgramNativeCaptureAdapter('key', vi.fn(), onError);
+
+    const startPromise = provider.start();
+    for (let i = 0; i < 10 && nativeState.recordings.length === 0; i += 1) await flush();
+    expect(nativeState.recordings).toHaveLength(1);
+
+    const stopPromise = provider.stop();
+    nativeState.nextPrepare.resolve();
+    await Promise.all([startPromise, stopPromise]);
+
+    expect(nativeState.recordings[0].stopCalls).toBe(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('uploads completed native chunks, emits transcripts, and deletes chunk files', async () => {
+    vi.useFakeTimers();
+    fileSystemMocks.uploadAsync.mockResolvedValueOnce({
+      body: '{"results":{"channels":[{"alternatives":[{"transcript":"Acererak awakens"}]}]}}',
+      status: 200,
+    });
+    const onTranscript = vi.fn();
+    const provider = new DeepgramNativeCaptureAdapter('native-key', onTranscript, vi.fn());
+
+    await provider.start();
+
+    try {
+      expect(nativeState.recordings).toHaveLength(1);
+      const firstChunk = nativeState.recordings[0];
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await flushUntil(() => fileSystemMocks.deleteAsync.mock.calls.length > 0);
+
+      expect(firstChunk.stopCalls).toBe(1);
+      expect(fileSystemMocks.uploadAsync).toHaveBeenCalledWith(
+        'https://api.deepgram.com/v1/listen?model=nova-2&punctuate=true&smart_format=true&language=en-US',
+        firstChunk.uri,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Token native-key',
+            'Content-Type': 'audio/mp4',
+          }),
+          httpMethod: 'POST',
+        }),
+      );
+      expect(fileSystemMocks.deleteAsync).toHaveBeenCalledWith(firstChunk.uri, { idempotent: true });
+      expect(onTranscript).toHaveBeenCalledWith('Acererak awakens');
+      expect(nativeState.recordings.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await provider.stop();
+    }
+  });
+});

--- a/src/stt/deepgram-native.ts
+++ b/src/stt/deepgram-native.ts
@@ -1,0 +1,159 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
+import {
+  createNativeAudioRecorder,
+  releaseNativeAudioRecorder,
+  requestNativeRecordingAccess,
+  type NativeAudioRecorder,
+} from './native-audio';
+
+import {
+  assertDeepgramApiKey,
+  DEEPGRAM_HTTP_URL,
+  DEEPGRAM_PARAMS,
+  extractDeepgramTranscript,
+} from './deepgram-shared';
+
+import type { STTProvider } from './index';
+
+export class DeepgramNativeCaptureAdapter implements STTProvider {
+  readonly name = 'Deepgram';
+  private active = false;
+  private chunkTimer: ReturnType<typeof setInterval> | null = null;
+  private nativeOperation: Promise<void> = Promise.resolve();
+  private recording: NativeAudioRecorder | null = null;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly onTranscript: (text: string) => void,
+    private readonly onError: (error: string) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    assertDeepgramApiKey(this.apiKey);
+    this.active = true;
+    await requestNativeRecordingAccess();
+    await this.enqueueNative(async () => { await this.startNativeChunks(); });
+  }
+
+  async pause(): Promise<void> {
+    this.active = false;
+    await this.enqueueNative(async () => {
+      this.clearNativeTimer();
+      await this.stopCurrentRecording();
+    });
+  }
+
+  async resume(): Promise<void> {
+    this.active = true;
+    await this.enqueueNative(async () => { await this.startNativeChunks(); });
+  }
+
+  async stop(): Promise<void> {
+    this.active = false;
+    await this.enqueueNative(async () => {
+      this.clearNativeTimer();
+      await this.stopCurrentRecording();
+    });
+  }
+
+  private enqueueNative(op: () => Promise<void>): Promise<void> {
+    const next = this.nativeOperation.catch(() => undefined).then(op);
+    this.nativeOperation = next.catch(() => undefined);
+    return next;
+  }
+
+  private clearNativeTimer(): void {
+    if (this.chunkTimer === null) return;
+    clearInterval(this.chunkTimer);
+    this.chunkTimer = null;
+  }
+
+  private async stopCurrentRecording(): Promise<void> {
+    const rec = this.recording;
+    this.recording = null;
+    if (!rec) return;
+    try {
+      await rec.stop();
+    } catch (e) {
+      if (this.active) throw e;
+    } finally {
+      releaseNativeAudioRecorder(rec);
+    }
+  }
+
+  private async startNativeChunks(): Promise<void> {
+    if (!this.active || this.recording) return;
+    this.clearNativeTimer();
+    await this.startChunk();
+    if (this.active && this.recording) this.chunkTimer = setInterval(() => { void this.rotateChunk(); }, 5000);
+  }
+
+  private async startChunk(): Promise<void> {
+    const rec = createNativeAudioRecorder();
+    try {
+      await rec.prepareToRecordAsync();
+      rec.record();
+      if (!this.active) {
+        await rec.stop().catch(() => {});
+        releaseNativeAudioRecorder(rec);
+        return;
+      }
+      this.recording = rec;
+    } catch (e) {
+      await rec.stop().catch(() => {});
+      releaseNativeAudioRecorder(rec);
+      if (this.active) throw e;
+    }
+  }
+
+  private async rotateChunk(): Promise<void> {
+    await this.enqueueNative(async () => {
+      if (!this.active || !this.recording) return;
+      const rec = this.recording;
+      this.recording = null;
+      try {
+        let uri: string | null = null;
+        try {
+          await rec.stop();
+          uri = rec.uri;
+        } finally {
+          releaseNativeAudioRecorder(rec);
+        }
+        if (uri) {
+          this.transcribeChunk(uri).then((text) => {
+            if (text && this.active) this.onTranscript(text);
+          }).catch((e: unknown) => {
+            if (this.active) this.onError(`Transcription failed: ${e instanceof Error ? e.message : String(e)}`);
+          });
+        }
+        if (this.active) await this.startChunk();
+      } catch (e) {
+        if (this.active) {
+          this.onError(`Recording error: ${e instanceof Error ? e.message : String(e)}`);
+          this.active = false;
+          this.clearNativeTimer();
+        }
+      }
+    });
+  }
+
+  private async transcribeChunk(uri: string): Promise<string> {
+    try {
+      const result = await FileSystem.uploadAsync(`${DEEPGRAM_HTTP_URL}?${DEEPGRAM_PARAMS}`, uri, {
+        headers: {
+          Authorization: `Token ${this.apiKey}`,
+          'Content-Type': 'audio/mp4',
+        },
+        httpMethod: 'POST',
+        uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
+      });
+      if (result.status < 200 || result.status >= 300) {
+        throw new Error(`Deepgram HTTP ${result.status}: ${result.body}`);
+      }
+      return extractDeepgramTranscript(result.body);
+    } finally {
+      FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => {});
+    }
+  }
+}

--- a/src/stt/deepgram-native.ts
+++ b/src/stt/deepgram-native.ts
@@ -1,20 +1,22 @@
 import * as FileSystem from 'expo-file-system/legacy';
 
 import {
+  assertDeepgramApiKey,
+  DEEPGRAM_HTTP_URL,
+  DEEPGRAM_PARAMS,
+  extractDeepgramTranscript,
+} from './deepgram-shared';
+import {
   createNativeAudioRecorder,
   releaseNativeAudioRecorder,
   requestNativeRecordingAccess,
   type NativeAudioRecorder,
 } from './native-audio';
 
-import {
-  assertDeepgramApiKey,
-  DEEPGRAM_HTTP_URL,
-  DEEPGRAM_PARAMS,
-  extractDeepgramTranscript,
-} from './deepgram-shared';
-
 import type { STTProvider } from './index';
+
+const NATIVE_AUDIO_CONTENT_TYPE = 'audio/mp4';
+const NATIVE_CHUNK_INTERVAL_MS = 5000;
 
 export class DeepgramNativeCaptureAdapter implements STTProvider {
   readonly name = 'Deepgram';
@@ -33,25 +35,30 @@ export class DeepgramNativeCaptureAdapter implements STTProvider {
     assertDeepgramApiKey(this.apiKey);
     this.active = true;
     await requestNativeRecordingAccess();
-    await this.enqueueNative(async () => { await this.startNativeChunks(); });
+    await this.startNativeCapture();
   }
 
   async pause(): Promise<void> {
     this.active = false;
-    await this.enqueueNative(async () => {
-      this.clearNativeTimer();
-      await this.stopCurrentRecording();
-    });
+    await this.stopNativeCapture();
   }
 
   async resume(): Promise<void> {
     this.active = true;
-    await this.enqueueNative(async () => { await this.startNativeChunks(); });
+    await this.startNativeCapture();
   }
 
   async stop(): Promise<void> {
     this.active = false;
-    await this.enqueueNative(async () => {
+    await this.stopNativeCapture();
+  }
+
+  private startNativeCapture(): Promise<void> {
+    return this.enqueueNative(async () => { await this.startNativeChunks(); });
+  }
+
+  private stopNativeCapture(): Promise<void> {
+    return this.enqueueNative(async () => {
       this.clearNativeTimer();
       await this.stopCurrentRecording();
     });
@@ -70,15 +77,15 @@ export class DeepgramNativeCaptureAdapter implements STTProvider {
   }
 
   private async stopCurrentRecording(): Promise<void> {
-    const rec = this.recording;
+    const recording = this.recording;
     this.recording = null;
-    if (!rec) return;
+    if (!recording) return;
     try {
-      await rec.stop();
+      await recording.stop();
     } catch (e) {
       if (this.active) throw e;
     } finally {
-      releaseNativeAudioRecorder(rec);
+      releaseNativeAudioRecorder(recording);
     }
   }
 
@@ -86,23 +93,25 @@ export class DeepgramNativeCaptureAdapter implements STTProvider {
     if (!this.active || this.recording) return;
     this.clearNativeTimer();
     await this.startChunk();
-    if (this.active && this.recording) this.chunkTimer = setInterval(() => { void this.rotateChunk(); }, 5000);
+    if (this.active && this.recording) {
+      this.chunkTimer = setInterval(() => { void this.rotateChunk(); }, NATIVE_CHUNK_INTERVAL_MS);
+    }
   }
 
   private async startChunk(): Promise<void> {
-    const rec = createNativeAudioRecorder();
+    const recording = createNativeAudioRecorder();
     try {
-      await rec.prepareToRecordAsync();
-      rec.record();
+      await recording.prepareToRecordAsync();
+      recording.record();
       if (!this.active) {
-        await rec.stop().catch(() => {});
-        releaseNativeAudioRecorder(rec);
+        await recording.stop().catch(() => {});
+        releaseNativeAudioRecorder(recording);
         return;
       }
-      this.recording = rec;
+      this.recording = recording;
     } catch (e) {
-      await rec.stop().catch(() => {});
-      releaseNativeAudioRecorder(rec);
+      await recording.stop().catch(() => {});
+      releaseNativeAudioRecorder(recording);
       if (this.active) throw e;
     }
   }
@@ -110,23 +119,11 @@ export class DeepgramNativeCaptureAdapter implements STTProvider {
   private async rotateChunk(): Promise<void> {
     await this.enqueueNative(async () => {
       if (!this.active || !this.recording) return;
-      const rec = this.recording;
+      const recording = this.recording;
       this.recording = null;
       try {
-        let uri: string | null = null;
-        try {
-          await rec.stop();
-          uri = rec.uri;
-        } finally {
-          releaseNativeAudioRecorder(rec);
-        }
-        if (uri) {
-          this.transcribeChunk(uri).then((text) => {
-            if (text && this.active) this.onTranscript(text);
-          }).catch((e: unknown) => {
-            if (this.active) this.onError(`Transcription failed: ${e instanceof Error ? e.message : String(e)}`);
-          });
-        }
+        const uri = await this.stopRecordingForUpload(recording);
+        if (uri) this.transcribeCompletedChunk(uri);
         if (this.active) await this.startChunk();
       } catch (e) {
         if (this.active) {
@@ -138,12 +135,29 @@ export class DeepgramNativeCaptureAdapter implements STTProvider {
     });
   }
 
+  private async stopRecordingForUpload(recording: NativeAudioRecorder): Promise<string | null> {
+    try {
+      await recording.stop();
+      return recording.uri;
+    } finally {
+      releaseNativeAudioRecorder(recording);
+    }
+  }
+
+  private transcribeCompletedChunk(uri: string): void {
+    void this.transcribeChunk(uri).then((text) => {
+      if (text && this.active) this.onTranscript(text);
+    }).catch((e: unknown) => {
+      if (this.active) this.onError(`Transcription failed: ${e instanceof Error ? e.message : String(e)}`);
+    });
+  }
+
   private async transcribeChunk(uri: string): Promise<string> {
     try {
       const result = await FileSystem.uploadAsync(`${DEEPGRAM_HTTP_URL}?${DEEPGRAM_PARAMS}`, uri, {
         headers: {
           Authorization: `Token ${this.apiKey}`,
-          'Content-Type': 'audio/mp4',
+          'Content-Type': NATIVE_AUDIO_CONTENT_TYPE,
         },
         httpMethod: 'POST',
         uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,

--- a/src/stt/deepgram-shared.ts
+++ b/src/stt/deepgram-shared.ts
@@ -1,0 +1,19 @@
+export const DEEPGRAM_HTTP_URL = 'https://api.deepgram.com/v1/listen';
+export const DEEPGRAM_WS_URL = 'wss://api.deepgram.com/v1/listen';
+export const DEEPGRAM_PARAMS = 'model=nova-2&punctuate=true&smart_format=true&language=en-US';
+
+export function assertDeepgramApiKey(apiKey: string): void {
+  if (!apiKey) throw new Error('Deepgram API key not set. Configure it in the Settings tab.');
+}
+
+export function getDeepgramCloseMessage(event: CloseEvent): string {
+  if (event.code === 1008) return 'Deepgram rejected the connection -- verify your API key.';
+  return `Deepgram connection closed (${event.code}). Check your network.`;
+}
+
+export function extractDeepgramTranscript(body: string): string {
+  const data = JSON.parse(body) as {
+    results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> };
+  };
+  return data?.results?.channels?.[0]?.alternatives?.[0]?.transcript ?? '';
+}

--- a/src/stt/deepgram-shared.ts
+++ b/src/stt/deepgram-shared.ts
@@ -2,6 +2,20 @@ export const DEEPGRAM_HTTP_URL = 'https://api.deepgram.com/v1/listen';
 export const DEEPGRAM_WS_URL = 'wss://api.deepgram.com/v1/listen';
 export const DEEPGRAM_PARAMS = 'model=nova-2&punctuate=true&smart_format=true&language=en-US';
 
+type DeepgramTranscriptChannel = {
+  alternatives?: Array<{ transcript?: string }>;
+};
+
+type DeepgramHttpResponse = {
+  results?: { channels?: DeepgramTranscriptChannel[] };
+};
+
+type DeepgramStreamingResponse = {
+  channel?: DeepgramTranscriptChannel;
+  is_final?: boolean;
+  type?: string;
+};
+
 export function assertDeepgramApiKey(apiKey: string): void {
   if (!apiKey) throw new Error('Deepgram API key not set. Configure it in the Settings tab.');
 }
@@ -12,8 +26,16 @@ export function getDeepgramCloseMessage(event: CloseEvent): string {
 }
 
 export function extractDeepgramTranscript(body: string): string {
-  const data = JSON.parse(body) as {
-    results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> };
-  };
-  return data?.results?.channels?.[0]?.alternatives?.[0]?.transcript ?? '';
+  const data = JSON.parse(body) as DeepgramHttpResponse | null;
+  return getFirstTranscript(data?.results?.channels?.[0]);
+}
+
+export function extractDeepgramFinalTranscript(message: string): string {
+  const data = JSON.parse(message) as DeepgramStreamingResponse;
+  if (data.type !== 'Results' || !data.is_final) return '';
+  return getFirstTranscript(data.channel);
+}
+
+function getFirstTranscript(channel: DeepgramTranscriptChannel | undefined): string {
+  return channel?.alternatives?.[0]?.transcript ?? '';
 }

--- a/src/stt/deepgram.test.ts
+++ b/src/stt/deepgram.test.ts
@@ -1,175 +1,110 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const platform = vi.hoisted(() => {
-  (globalThis as any).__DEV__ = false;
-  return { OS: 'ios' };
-});
+const platform = vi.hoisted(() => ({ OS: 'web' }));
 
-type Deferred = {
-  promise: Promise<void>;
-  resolve: () => void;
-};
-
-const nativeState = vi.hoisted(() => {
-  class MockRecording {
+const adapterState = vi.hoisted(() => {
+  class MockBrowserAdapter {
+    pauseCalls = 0;
+    resumeCalls = 0;
+    startCalls = 0;
     stopCalls = 0;
-    uri = 'file:///chunk.m4a';
 
-    constructor() {
-      state.recordings.push(this);
+    constructor(
+      readonly apiKey: string,
+      readonly onTranscript: (text: string) => void,
+      readonly onError: (error: string) => void,
+    ) {
+      state.browserInstances.push(this);
     }
 
-    async prepareToRecordAsync(): Promise<void> {
-      if (!state.nextPrepare) return;
-      await state.nextPrepare.promise;
+    async start(): Promise<void> { this.startCalls += 1; }
+    async pause(): Promise<void> { this.pauseCalls += 1; }
+    async resume(): Promise<void> { this.resumeCalls += 1; }
+    async stop(): Promise<void> { this.stopCalls += 1; }
+  }
+
+  class MockNativeAdapter {
+    pauseCalls = 0;
+    resumeCalls = 0;
+    startCalls = 0;
+    stopCalls = 0;
+
+    constructor(
+      readonly apiKey: string,
+      readonly onTranscript: (text: string) => void,
+      readonly onError: (error: string) => void,
+    ) {
+      state.nativeInstances.push(this);
     }
 
-    record(): void {}
-
-    async stop(): Promise<void> {
-      this.stopCalls += 1;
-    }
-
-    release(): void {}
+    async start(): Promise<void> { this.startCalls += 1; }
+    async pause(): Promise<void> { this.pauseCalls += 1; }
+    async resume(): Promise<void> { this.resumeCalls += 1; }
+    async stop(): Promise<void> { this.stopCalls += 1; }
   }
 
   const state = {
-    MockRecording,
-    recordings: [] as MockRecording[],
-    nextPrepare: null as Deferred | null,
+    MockBrowserAdapter,
+    MockNativeAdapter,
+    browserInstances: [] as MockBrowserAdapter[],
+    nativeInstances: [] as MockNativeAdapter[],
   };
   return state;
 });
 
 vi.mock('react-native', () => ({ Platform: platform }));
-vi.mock('expo-audio', () => ({
-  RecordingPresets: { HIGH_QUALITY: {} },
-  requestRecordingPermissionsAsync: vi.fn(async () => ({ granted: true })),
-  setAudioModeAsync: vi.fn(async () => undefined),
+vi.mock('./deepgram-browser', () => ({
+  DeepgramBrowserCaptureAdapter: adapterState.MockBrowserAdapter,
 }));
-vi.mock('expo-audio/build/AudioModule', () => ({
-  default: { AudioRecorder: nativeState.MockRecording },
-}));
-vi.mock('expo-audio/build/utils/options', () => ({
-  createRecordingOptions: vi.fn((options) => options),
-}));
-vi.mock('expo-file-system/legacy', () => ({
-  default: {},
-  FileSystemUploadType: { BINARY_CONTENT: 'BINARY_CONTENT' },
-  uploadAsync: vi.fn(async () => ({ status: 200, body: '{"results":{"channels":[{"alternatives":[{"transcript":""}]}]}}' })),
-  deleteAsync: vi.fn(async () => undefined),
+vi.mock('./deepgram-native', () => ({
+  DeepgramNativeCaptureAdapter: adapterState.MockNativeAdapter,
 }));
 
 import { DeepgramProvider } from './deepgram';
 
-function deferred(): Deferred {
-  let resolve!: () => void;
-  const promise = new Promise<void>((res) => { resolve = res; });
-  return { promise, resolve };
-}
-
-async function flush(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-}
-
-describe('DeepgramProvider lifecycle', () => {
+describe('DeepgramProvider internal adapter selection', () => {
   beforeEach(() => {
-    platform.OS = 'ios';
-    nativeState.recordings.length = 0;
-    nativeState.nextPrepare = null;
-    vi.clearAllMocks();
-  });
-
-  it('unloads native recording if stop happens during first chunk startup', async () => {
-    nativeState.nextPrepare = deferred();
-    const onError = vi.fn();
-    const provider = new DeepgramProvider('key', vi.fn(), onError);
-
-    const startPromise = provider.start();
-    for (let i = 0; i < 10 && nativeState.recordings.length === 0; i++) {
-      await flush();
-    }
-    expect(nativeState.recordings).toHaveLength(1);
-
-    const stopPromise = provider.stop();
-    nativeState.nextPrepare.resolve();
-    await Promise.all([startPromise, stopPromise]);
-
-    expect(nativeState.recordings[0].stopCalls).toBe(1);
-    expect(onError).not.toHaveBeenCalled();
-  });
-
-  it('cleans up web mic stream when stopped before Deepgram websocket opens', async () => {
     platform.OS = 'web';
-    const trackStop = vi.fn();
-    const stream = { getTracks: () => [{ stop: trackStop }] };
-    const sockets: Array<{ close: () => void; onclose: ((event: CloseEvent) => void) | null }> = [];
-
-    Object.defineProperty(globalThis, 'navigator', {
-      configurable: true,
-      value: { mediaDevices: { getUserMedia: vi.fn(async () => stream) } },
-    });
-    (globalThis as any).MediaRecorder = class {
-      static isTypeSupported() { return true; }
-    };
-    (globalThis as any).WebSocket = class {
-      static OPEN = 1;
-      static CLOSING = 2;
-      static CLOSED = 3;
-      readyState = 0;
-      onclose: ((event: CloseEvent) => void) | null = null;
-
-      constructor() {
-        sockets.push(this);
-      }
-
-      close() {
-        this.readyState = 3;
-        this.onclose?.({ code: 1000 } as CloseEvent);
-      }
-    };
-
-    const provider = new DeepgramProvider('key', vi.fn(), vi.fn());
-    const startPromise = provider.start();
-    await flush();
-
-    await expect(provider.stop()).resolves.toBeUndefined();
-    await expect(startPromise).rejects.toThrow('Deepgram connection closed');
-    expect(sockets).toHaveLength(1);
-    expect(trackStop).toHaveBeenCalledTimes(1);
+    adapterState.browserInstances.length = 0;
+    adapterState.nativeInstances.length = 0;
   });
 
-  it('cleans up web mic stream when stopped while getUserMedia is pending', async () => {
-    platform.OS = 'web';
-    const trackStop = vi.fn();
-    const stream = { getTracks: () => [{ stop: trackStop }] };
-    let resolveStream!: (value: typeof stream) => void;
-    const getUserMedia = vi.fn(() => new Promise<typeof stream>((resolve) => { resolveStream = resolve; }));
+  it('keeps browser capture hidden behind the Deepgram provider seam on web', async () => {
+    const provider = new DeepgramProvider('browser-key', vi.fn(), vi.fn());
 
-    Object.defineProperty(globalThis, 'navigator', {
-      configurable: true,
-      value: { mediaDevices: { getUserMedia } },
-    });
-    (globalThis as any).MediaRecorder = class {
-      static isTypeSupported() { return true; }
-    };
-    const sockets: unknown[] = [];
-    (globalThis as any).WebSocket = class {
-      constructor() {
-        sockets.push(this);
-      }
-    };
-
-    const provider = new DeepgramProvider('key', vi.fn(), vi.fn());
-    const startPromise = provider.start();
-    await flush();
-
+    await provider.start();
+    await provider.pause();
+    await provider.resume();
     await provider.stop();
-    resolveStream(stream);
 
-    await expect(startPromise).rejects.toThrow('microphone access completed');
-    expect(trackStop).toHaveBeenCalledTimes(1);
-    expect(sockets).toHaveLength(0);
+    expect(provider.name).toBe('Deepgram');
+    expect(adapterState.browserInstances).toHaveLength(1);
+    expect(adapterState.nativeInstances).toHaveLength(0);
+    expect(adapterState.browserInstances[0].apiKey).toBe('browser-key');
+    expect(adapterState.browserInstances[0].startCalls).toBe(1);
+    expect(adapterState.browserInstances[0].pauseCalls).toBe(1);
+    expect(adapterState.browserInstances[0].resumeCalls).toBe(1);
+    expect(adapterState.browserInstances[0].stopCalls).toBe(1);
+  });
+
+  it('keeps native capture hidden behind the Deepgram provider seam off web', async () => {
+    platform.OS = 'ios';
+    const provider = new DeepgramProvider('native-key', vi.fn(), vi.fn());
+
+    await provider.start();
+
+    expect(provider.name).toBe('Deepgram');
+    expect(adapterState.browserInstances).toHaveLength(0);
+    expect(adapterState.nativeInstances).toHaveLength(1);
+    expect(adapterState.nativeInstances[0].apiKey).toBe('native-key');
+    expect(adapterState.nativeInstances[0].startCalls).toBe(1);
+  });
+
+  it('preserves the missing API key startup error before starting an adapter', async () => {
+    const provider = new DeepgramProvider('', vi.fn(), vi.fn());
+
+    await expect(provider.start()).rejects.toThrow('Deepgram API key not set');
+    expect(adapterState.browserInstances).toHaveLength(1);
+    expect(adapterState.browserInstances[0].startCalls).toBe(0);
   });
 });

--- a/src/stt/deepgram.ts
+++ b/src/stt/deepgram.ts
@@ -6,18 +6,19 @@ import { assertDeepgramApiKey } from './deepgram-shared';
 
 import type { STTProvider } from './index';
 
+type TranscriptHandler = (text: string) => void;
+type ErrorHandler = (error: string) => void;
+
 export class DeepgramProvider implements STTProvider {
   readonly name = 'Deepgram';
   private readonly adapter: STTProvider;
 
   constructor(
     private readonly apiKey: string,
-    onTranscript: (text: string) => void,
-    onError: (error: string) => void,
+    onTranscript: TranscriptHandler,
+    onError: ErrorHandler,
   ) {
-    this.adapter = Platform.OS === 'web'
-      ? new DeepgramBrowserCaptureAdapter(apiKey, onTranscript, onError)
-      : new DeepgramNativeCaptureAdapter(apiKey, onTranscript, onError);
+    this.adapter = createDeepgramCaptureAdapter(apiKey, onTranscript, onError);
   }
 
   async start(): Promise<void> {
@@ -28,4 +29,15 @@ export class DeepgramProvider implements STTProvider {
   pause(): void | Promise<void> { return this.adapter.pause(); }
   resume(): void | Promise<void> { return this.adapter.resume(); }
   stop(): void | Promise<void> { return this.adapter.stop(); }
+}
+
+function createDeepgramCaptureAdapter(
+  apiKey: string,
+  onTranscript: TranscriptHandler,
+  onError: ErrorHandler,
+): STTProvider {
+  if (Platform.OS === 'web') {
+    return new DeepgramBrowserCaptureAdapter(apiKey, onTranscript, onError);
+  }
+  return new DeepgramNativeCaptureAdapter(apiKey, onTranscript, onError);
 }

--- a/src/stt/deepgram.ts
+++ b/src/stt/deepgram.ts
@@ -1,298 +1,31 @@
-import * as FileSystem from 'expo-file-system/legacy';
 import { Platform } from 'react-native';
 
-import { createNativeAudioRecorder, releaseNativeAudioRecorder, requestNativeRecordingAccess, type NativeAudioRecorder } from './native-audio';
+import { DeepgramBrowserCaptureAdapter } from './deepgram-browser';
+import { DeepgramNativeCaptureAdapter } from './deepgram-native';
+import { assertDeepgramApiKey } from './deepgram-shared';
 
-import { STTProvider } from './index';
-
-const DG_BASE = 'https://api.deepgram.com/v1/listen';
-const DG_WS = 'wss://api.deepgram.com/v1/listen';
-const DG_PARAMS = 'model=nova-2&punctuate=true&smart_format=true&language=en-US';
+import type { STTProvider } from './index';
 
 export class DeepgramProvider implements STTProvider {
   readonly name = 'Deepgram';
-  private apiKey: string;
-  private onTranscript: (text: string) => void;
-  private onError: (error: string) => void;
-  private active = false;
-  private ws: WebSocket | null = null;
-  private stream: MediaStream | null = null;
-  private recorder: MediaRecorder | null = null;
+  private readonly adapter: STTProvider;
 
-  private chunkTimer: ReturnType<typeof setInterval> | null = null;
-  private recording: NativeAudioRecorder | null = null;
-  private nativeOperation: Promise<void> = Promise.resolve();
-
-  constructor(apiKey: string, onTranscript: (text: string) => void, onError: (error: string) => void) {
-    this.apiKey = apiKey;
-    this.onTranscript = onTranscript;
-    this.onError = onError;
+  constructor(
+    private readonly apiKey: string,
+    onTranscript: (text: string) => void,
+    onError: (error: string) => void,
+  ) {
+    this.adapter = Platform.OS === 'web'
+      ? new DeepgramBrowserCaptureAdapter(apiKey, onTranscript, onError)
+      : new DeepgramNativeCaptureAdapter(apiKey, onTranscript, onError);
   }
 
   async start(): Promise<void> {
-    if (!this.apiKey) {
-      throw new Error('Deepgram API key not set. Configure it in the Settings tab.');
-    }
-    this.active = true;
-    if (Platform.OS === 'web') {
-      await this.startWeb();
-    } else {
-      await this.startNative();
-    }
+    assertDeepgramApiKey(this.apiKey);
+    await this.adapter.start();
   }
 
-  private getDeepgramCloseMessage(event: CloseEvent): string {
-    if (event.code === 1008) return 'Deepgram rejected the connection -- verify your API key.';
-    return `Deepgram connection closed (${event.code}). Check your network.`;
-  }
-
-  private getRecorderOptions(): MediaRecorderOptions | undefined {
-    if (typeof MediaRecorder === 'undefined') return undefined;
-    const supportedTypes = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'];
-    const mimeType = supportedTypes.find((type) => MediaRecorder.isTypeSupported(type));
-    return mimeType ? { mimeType } : undefined;
-  }
-
-  private cleanupWeb(): void {
-    const recorder = this.recorder;
-    this.recorder = null;
-    try {
-      if (recorder && recorder.state !== 'inactive') recorder.stop();
-    } catch {}
-    const ws = this.ws;
-    this.ws = null;
-    try {
-      if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) ws.close();
-    } catch {}
-    this.stream?.getTracks().forEach((track) => track.stop());
-    this.stream = null;
-  }
-
-  private async startWeb(): Promise<void> {
-    if (!navigator.mediaDevices?.getUserMedia) throw new Error('Microphone capture is not available in this browser.');
-    if (typeof MediaRecorder === 'undefined') throw new Error('Browser audio recording is not available.');
-
-    let stream: MediaStream;
-    try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    } catch (e) {
-      const detail = e instanceof Error ? e.message : String(e);
-      throw new Error(`Microphone access denied. ${detail}`);
-    }
-    if (!this.active) { stream.getTracks().forEach((track) => track.stop()); throw new Error('Recording was stopped before microphone access completed.'); }
-    this.stream = stream;
-
-    await new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(`${DG_WS}?${DG_PARAMS}`, ['token', this.apiKey]);
-      this.ws = ws;
-      let settled = false;
-
-      const settle = (err?: Error) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeout);
-        if (err) {
-          this.active = false;
-          this.cleanupWeb();
-          reject(err);
-        } else {
-          resolve();
-        }
-      };
-
-      const timeout = setTimeout(() => {
-        settle(new Error('Deepgram connection timed out. Check your API key and network.'));
-      }, 10000);
-
-      ws.onopen = () => {
-        if (!this.active || !this.stream) {
-          settle(new Error('Recording was stopped before Deepgram connected.'));
-          return;
-        }
-        try {
-          const recorder = new MediaRecorder(this.stream, this.getRecorderOptions());
-          this.recorder = recorder;
-          recorder.ondataavailable = (e) => {
-            if (e.data.size > 0 && this.ws?.readyState === WebSocket.OPEN) {
-              this.ws.send(e.data);
-            }
-          };
-          recorder.onerror = (event) => {
-            const err = event instanceof ErrorEvent ? event.message : 'Unknown recording error';
-            if (!settled) { settle(new Error(`Mic recording error: ${err}`)); return; }
-            if (this.active) this.onError(`Mic recording error: ${err}`);
-          };
-          recorder.start(250);
-          settle();
-        } catch (e) {
-          settle(new Error(`Failed to start browser recorder: ${e instanceof Error ? e.message : String(e)}`));
-        }
-      };
-
-      ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data as string);
-          if (data.type === 'Results' && data.is_final) {
-            const text: string = data.channel?.alternatives?.[0]?.transcript ?? '';
-            if (text.trim() && this.active) this.onTranscript(text.trim());
-          }
-        } catch (e) {
-          if (this.active) this.onError(`Unexpected Deepgram response: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      };
-
-      ws.onerror = () => {
-        const err = new Error('Deepgram connection error. Check your API key and network.');
-        if (!settled) { settle(err); return; }
-        if (this.active) this.onError(err.message);
-      };
-
-      ws.onclose = (event) => {
-        if (!settled) { settle(new Error(this.getDeepgramCloseMessage(event))); return; }
-        if (this.active) {
-          this.onError(this.getDeepgramCloseMessage(event));
-          this.active = false;
-          this.cleanupWeb();
-        }
-      };
-    });
-  }
-
-  private async startNative(): Promise<void> {
-    await requestNativeRecordingAccess();
-    await this.enqueueNative(async () => { await this.startNativeChunks(); });
-  }
-
-  private enqueueNative(op: () => Promise<void>): Promise<void> {
-    const next = this.nativeOperation.catch(() => undefined).then(op);
-    this.nativeOperation = next.catch(() => undefined);
-    return next;
-  }
-
-  private clearNativeTimer(): void {
-    if (this.chunkTimer !== null) { clearInterval(this.chunkTimer); this.chunkTimer = null; }
-  }
-
-  private async stopCurrentRecording(): Promise<void> {
-    const rec = this.recording;
-    this.recording = null;
-    if (!rec) return;
-    try {
-      await rec.stop();
-    } catch (e) {
-      if (this.active) throw e;
-    } finally {
-      releaseNativeAudioRecorder(rec);
-    }
-  }
-
-  private async startNativeChunks(): Promise<void> {
-    if (!this.active || this.recording) return;
-    this.clearNativeTimer();
-    await this.startChunk();
-    if (this.active && this.recording) this.chunkTimer = setInterval(() => { void this.rotateChunk(); }, 5000);
-  }
-
-  private async startChunk(): Promise<void> {
-    const rec = createNativeAudioRecorder();
-    try {
-      await rec.prepareToRecordAsync();
-      rec.record();
-      if (!this.active) {
-        await rec.stop().catch(() => {});
-        releaseNativeAudioRecorder(rec);
-        return;
-      }
-      this.recording = rec;
-    } catch (e) {
-      await rec.stop().catch(() => {});
-      releaseNativeAudioRecorder(rec);
-      if (this.active) throw e;
-    }
-  }
-
-  private async rotateChunk(): Promise<void> {
-    await this.enqueueNative(async () => {
-      if (!this.active || !this.recording) return;
-      const rec = this.recording;
-      this.recording = null;
-      try {
-        let uri: string | null = null;
-        try {
-          await rec.stop();
-          uri = rec.uri;
-        } finally {
-          releaseNativeAudioRecorder(rec);
-        }
-        if (uri) {
-          this.transcribeChunk(uri).then((text) => {
-            if (text && this.active) this.onTranscript(text);
-          }).catch((e: unknown) => {
-            if (this.active) this.onError(`Transcription failed: ${e instanceof Error ? e.message : String(e)}`);
-          });
-        }
-        if (this.active) await this.startChunk();
-      } catch (e) {
-        if (this.active) {
-          this.onError(`Recording error: ${e instanceof Error ? e.message : String(e)}`);
-          this.active = false;
-          this.clearNativeTimer();
-        }
-      }
-    });
-  }
-
-  private async transcribeChunk(uri: string): Promise<string> {
-    try {
-      const result = await FileSystem.uploadAsync(`${DG_BASE}?${DG_PARAMS}`, uri, {
-        httpMethod: 'POST',
-        uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          'Content-Type': 'audio/mp4',
-        },
-      });
-      if (result.status < 200 || result.status >= 300) {
-        throw new Error(`Deepgram HTTP ${result.status}: ${result.body}`);
-      }
-      const data = JSON.parse(result.body) as {
-        results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> };
-      };
-      return data?.results?.channels?.[0]?.alternatives?.[0]?.transcript ?? '';
-    } finally {
-      FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => {});
-    }
-  }
-
-  async pause(): Promise<void> {
-    this.active = false;
-    if (Platform.OS === 'web') {
-      if (this.recorder?.state === 'recording') this.recorder.pause();
-      return;
-    }
-    await this.enqueueNative(async () => { this.clearNativeTimer(); await this.stopCurrentRecording(); });
-  }
-
-  async resume(): Promise<void> {
-    this.active = true;
-    if (Platform.OS === 'web') {
-      if (this.recorder?.state === 'paused' && this.ws?.readyState === WebSocket.OPEN) {
-        this.recorder.resume();
-        return;
-      }
-      this.cleanupWeb();
-      await this.startWeb();
-      return;
-    }
-    await this.enqueueNative(async () => { await this.startNativeChunks(); });
-  }
-
-  async stop(): Promise<void> {
-    this.active = false;
-    if (Platform.OS === 'web') {
-      this.cleanupWeb();
-      return;
-    }
-    await this.enqueueNative(async () => { this.clearNativeTimer(); await this.stopCurrentRecording(); });
-  }
+  pause(): void | Promise<void> { return this.adapter.pause(); }
+  resume(): void | Promise<void> { return this.adapter.resume(); }
+  stop(): void | Promise<void> { return this.adapter.stop(); }
 }

--- a/src/stt/lifecycle-safe-provider.test.ts
+++ b/src/stt/lifecycle-safe-provider.test.ts
@@ -4,20 +4,17 @@ import { createLateEventSafeSTTProvider } from './lifecycle-safe-provider';
 
 import type { STTProvider } from './index';
 
-type Deferred = {
+type RejectablePromise = {
   promise: Promise<void>;
   reject: (error: unknown) => void;
-  resolve: () => void;
 };
 
-function deferred(): Deferred {
+function rejectablePromise(): RejectablePromise {
   let reject!: (error: unknown) => void;
-  let resolve!: () => void;
-  const promise = new Promise<void>((res, rej) => {
-    resolve = res;
+  const promise = new Promise<void>((_resolve, rej) => {
     reject = rej;
   });
-  return { promise, reject, resolve };
+  return { promise, reject };
 }
 
 class FakeCaptureAdapter implements STTProvider {
@@ -84,7 +81,7 @@ describe('late-event-safe STT provider', () => {
   });
 
   it('cancels stop-during-start so startup completions cannot deliver stale events', async () => {
-    const startup = deferred();
+    const startup = rejectablePromise();
     const { adapters, onError, onTranscript, provider } = makeProvider((adapter) => {
       adapter.startResult = startup.promise;
     });

--- a/src/stt/lifecycle-safe-provider.test.ts
+++ b/src/stt/lifecycle-safe-provider.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createLateEventSafeSTTProvider } from './lifecycle-safe-provider';
+
+import type { STTProvider } from './index';
+
+type Deferred = {
+  promise: Promise<void>;
+  reject: (error: unknown) => void;
+  resolve: () => void;
+};
+
+function deferred(): Deferred {
+  let reject!: (error: unknown) => void;
+  let resolve!: () => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+class FakeCaptureAdapter implements STTProvider {
+  readonly name = 'Fake Capture';
+  startCalls = 0;
+  stopCalls = 0;
+  startResult: Promise<void> | null = null;
+  startError: unknown = null;
+
+  constructor(
+    private readonly onTranscript: (text: string) => void,
+    private readonly onError: (error: string) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    this.startCalls += 1;
+    if (this.startError) throw this.startError;
+    if (this.startResult) await this.startResult;
+  }
+
+  pause(): void {}
+  resume(): void {}
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+  }
+
+  emitTranscript(text: string): void {
+    this.onTranscript(text);
+  }
+
+  emitError(error: string): void {
+    this.onError(error);
+  }
+}
+
+function makeProvider(configure?: (adapter: FakeCaptureAdapter) => void) {
+  const adapters: FakeCaptureAdapter[] = [];
+  const onTranscript = vi.fn();
+  const onError = vi.fn();
+  const provider = createLateEventSafeSTTProvider((safeTranscript, safeError) => {
+    const adapter = new FakeCaptureAdapter(safeTranscript, safeError);
+    configure?.(adapter);
+    adapters.push(adapter);
+    return adapter;
+  }, onTranscript, onError);
+
+  return { adapters, onError, onTranscript, provider };
+}
+
+describe('late-event-safe STT provider', () => {
+  it('drops transcript and error events from a stopped capture generation', async () => {
+    const { adapters, onError, onTranscript, provider } = makeProvider();
+
+    await provider.start();
+    adapters[0].emitTranscript('heard while active');
+    await provider.stop();
+    adapters[0].emitTranscript('late after stop');
+    adapters[0].emitError('late error after stop');
+
+    expect(onTranscript).toHaveBeenCalledTimes(1);
+    expect(onTranscript).toHaveBeenCalledWith('heard while active');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('cancels stop-during-start so startup completions cannot deliver stale events', async () => {
+    const startup = deferred();
+    const { adapters, onError, onTranscript, provider } = makeProvider((adapter) => {
+      adapter.startResult = startup.promise;
+    });
+
+    const start = provider.start();
+    adapters[0].emitTranscript('too early');
+    const stop = provider.stop();
+    startup.reject(new Error('mic failed after stop'));
+    adapters[0].emitError('late startup error');
+
+    await expect(start).resolves.toBeUndefined();
+    await expect(stop).resolves.toBeUndefined();
+    expect(adapters[0].stopCalls).toBe(1);
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('suppresses paused events and resumes with only the current generation enabled', async () => {
+    const { adapters, onError, onTranscript, provider } = makeProvider();
+
+    await provider.start();
+    const pausedAdapter = adapters[0];
+    await provider.pause();
+    pausedAdapter.emitTranscript('heard while paused');
+    pausedAdapter.emitError('paused error');
+
+    await provider.resume();
+    expect(adapters).toHaveLength(2);
+    pausedAdapter.emitTranscript('old generation after resume');
+    pausedAdapter.emitError('old error after resume');
+    adapters[1].emitTranscript('current generation');
+    adapters[1].emitError('current error');
+
+    expect(pausedAdapter.stopCalls).toBe(1);
+    expect(onTranscript).toHaveBeenCalledTimes(1);
+    expect(onTranscript).toHaveBeenCalledWith('current generation');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith('current error');
+  });
+
+  it('propagates current startup failures so callers can show user-facing errors', async () => {
+    const { onError, provider } = makeProvider((adapter) => {
+      adapter.startError = new Error('permission denied');
+    });
+
+    await expect(provider.start()).rejects.toThrow('permission denied');
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/stt/lifecycle-safe-provider.ts
+++ b/src/stt/lifecycle-safe-provider.ts
@@ -6,14 +6,14 @@ export type STTProviderFactory = (
 ) => STTProvider;
 
 type CaptureInstance = {
-  generation: number;
-  provider: STTProvider;
+  readonly generation: number;
+  readonly provider: STTProvider;
 };
 
 export class LateEventSafeSTTProvider implements STTProvider {
   readonly name: string;
-  private activeGeneration: number | null = null;
-  private current: CaptureInstance | null;
+  private currentCapture: CaptureInstance | null;
+  private deliveryGeneration: number | null = null;
   private nextGeneration = 0;
   private startInFlight: Promise<void> | null = null;
 
@@ -22,36 +22,18 @@ export class LateEventSafeSTTProvider implements STTProvider {
     private readonly onTranscript: (text: string) => void,
     private readonly onError: (error: string) => void,
   ) {
-    this.current = this.createInstance();
-    this.name = this.current.provider.name;
+    this.currentCapture = this.createCapture();
+    this.name = this.currentCapture.provider.name;
   }
 
   start(): Promise<void> {
     if (this.startInFlight) return this.startInFlight;
 
-    const instance = this.current ?? this.createInstance();
-    this.current = instance;
-    this.activeGeneration = null;
+    const capture = this.currentCapture ?? this.createCapture();
+    this.currentCapture = capture;
+    this.deliveryGeneration = null;
 
-    let startup: Promise<void>;
-    try {
-      startup = Promise.resolve(instance.provider.start());
-    } catch (error) {
-      startup = Promise.reject(error);
-    }
-
-    const command = startup.then(
-      () => {
-        if (!this.isCurrent(instance)) return;
-        this.activeGeneration = instance.generation;
-      },
-      (error: unknown) => {
-        if (!this.isCurrent(instance)) return;
-        this.current = null;
-        this.activeGeneration = null;
-        throw error;
-      },
-    );
+    const command = this.startCapture(capture);
     this.startInFlight = command;
     command.then(
       () => this.clearStartInFlight(command),
@@ -60,18 +42,40 @@ export class LateEventSafeSTTProvider implements STTProvider {
     return command;
   }
 
-  pause(): Promise<void> { return this.invalidateAndStopCurrent(); }
+  pause(): Promise<void> { return this.stopCurrentCapture(); }
   resume(): Promise<void> { return this.start(); }
-  stop(): Promise<void> { return this.invalidateAndStopCurrent(); }
+  stop(): Promise<void> { return this.stopCurrentCapture(); }
 
-  private createInstance(): CaptureInstance {
-    const generation = this.nextGeneration + 1;
-    this.nextGeneration = generation;
+  private createCapture(): CaptureInstance {
+    this.nextGeneration += 1;
+    const generation = this.nextGeneration;
     const provider = this.createProvider(
       (text) => this.emitTranscript(text, generation),
       (error) => this.emitError(error, generation),
     );
     return { generation, provider };
+  }
+
+  private startCapture(capture: CaptureInstance): Promise<void> {
+    let startup: Promise<void>;
+    try {
+      startup = Promise.resolve(capture.provider.start());
+    } catch (error) {
+      startup = Promise.reject(error);
+    }
+
+    return startup.then(
+      () => {
+        if (!this.isCurrentCapture(capture)) return;
+        this.deliveryGeneration = capture.generation;
+      },
+      (error: unknown) => {
+        if (!this.isCurrentCapture(capture)) return;
+        this.currentCapture = null;
+        this.deliveryGeneration = null;
+        throw error;
+      },
+    );
   }
 
   private emitTranscript(text: string, generation: number): void {
@@ -80,30 +84,31 @@ export class LateEventSafeSTTProvider implements STTProvider {
 
   private emitError(error: string, generation: number): void {
     if (!this.canDeliver(generation)) return;
-    this.activeGeneration = null;
+    this.deliveryGeneration = null;
     this.onError(error);
   }
 
   private canDeliver(generation: number): boolean {
-    return this.activeGeneration === generation && this.current?.generation === generation;
+    return this.deliveryGeneration === generation && this.currentCapture?.generation === generation;
   }
 
-  private isCurrent(instance: CaptureInstance): boolean {
-    return this.current === instance && this.current.generation === instance.generation;
+  private isCurrentCapture(capture: CaptureInstance): boolean {
+    const current = this.currentCapture;
+    return current !== null && current === capture && current.generation === capture.generation;
   }
 
-  private invalidateAndStopCurrent(): Promise<void> {
-    const instance = this.current;
-    this.current = null;
-    this.activeGeneration = null;
+  private stopCurrentCapture(): Promise<void> {
+    const capture = this.currentCapture;
+    this.currentCapture = null;
+    this.deliveryGeneration = null;
     this.startInFlight = null;
-    if (!instance) return Promise.resolve();
-    return this.stopInstance(instance.provider);
+    if (!capture) return Promise.resolve();
+    return this.stopProvider(capture.provider);
   }
 
-  private async stopInstance(provider: STTProvider): Promise<void> {
+  private async stopProvider(provider: STTProvider): Promise<void> {
     try {
-      await Promise.resolve(provider.stop());
+      await provider.stop();
     } catch {}
   }
 

--- a/src/stt/lifecycle-safe-provider.ts
+++ b/src/stt/lifecycle-safe-provider.ts
@@ -1,0 +1,121 @@
+import type { STTProvider } from './index';
+
+export type STTProviderFactory = (
+  onTranscript: (text: string) => void,
+  onError: (error: string) => void,
+) => STTProvider;
+
+type CaptureInstance = {
+  generation: number;
+  provider: STTProvider;
+};
+
+export class LateEventSafeSTTProvider implements STTProvider {
+  readonly name: string;
+  private activeGeneration: number | null = null;
+  private current: CaptureInstance | null;
+  private nextGeneration = 0;
+  private startInFlight: Promise<void> | null = null;
+
+  constructor(
+    private readonly createProvider: STTProviderFactory,
+    private readonly onTranscript: (text: string) => void,
+    private readonly onError: (error: string) => void,
+  ) {
+    this.current = this.createInstance();
+    this.name = this.current.provider.name;
+  }
+
+  start(): Promise<void> {
+    if (this.startInFlight) return this.startInFlight;
+
+    const instance = this.current ?? this.createInstance();
+    this.current = instance;
+    this.activeGeneration = null;
+
+    let startup: Promise<void>;
+    try {
+      startup = Promise.resolve(instance.provider.start());
+    } catch (error) {
+      startup = Promise.reject(error);
+    }
+
+    const command = startup.then(
+      () => {
+        if (!this.isCurrent(instance)) return;
+        this.activeGeneration = instance.generation;
+      },
+      (error: unknown) => {
+        if (!this.isCurrent(instance)) return;
+        this.current = null;
+        this.activeGeneration = null;
+        throw error;
+      },
+    );
+    this.startInFlight = command;
+    command.then(
+      () => this.clearStartInFlight(command),
+      () => this.clearStartInFlight(command),
+    );
+    return command;
+  }
+
+  pause(): Promise<void> { return this.invalidateAndStopCurrent(); }
+  resume(): Promise<void> { return this.start(); }
+  stop(): Promise<void> { return this.invalidateAndStopCurrent(); }
+
+  private createInstance(): CaptureInstance {
+    const generation = this.nextGeneration + 1;
+    this.nextGeneration = generation;
+    const provider = this.createProvider(
+      (text) => this.emitTranscript(text, generation),
+      (error) => this.emitError(error, generation),
+    );
+    return { generation, provider };
+  }
+
+  private emitTranscript(text: string, generation: number): void {
+    if (this.canDeliver(generation)) this.onTranscript(text);
+  }
+
+  private emitError(error: string, generation: number): void {
+    if (!this.canDeliver(generation)) return;
+    this.activeGeneration = null;
+    this.onError(error);
+  }
+
+  private canDeliver(generation: number): boolean {
+    return this.activeGeneration === generation && this.current?.generation === generation;
+  }
+
+  private isCurrent(instance: CaptureInstance): boolean {
+    return this.current === instance && this.current.generation === instance.generation;
+  }
+
+  private invalidateAndStopCurrent(): Promise<void> {
+    const instance = this.current;
+    this.current = null;
+    this.activeGeneration = null;
+    this.startInFlight = null;
+    if (!instance) return Promise.resolve();
+    return this.stopInstance(instance.provider);
+  }
+
+  private async stopInstance(provider: STTProvider): Promise<void> {
+    try {
+      await Promise.resolve(provider.stop());
+    } catch {}
+  }
+
+  private clearStartInFlight(command: Promise<void>): void {
+    if (this.startInFlight === command) this.startInFlight = null;
+  }
+}
+
+export function createLateEventSafeSTTProvider(
+  createProvider: STTProviderFactory,
+  onTranscript: (text: string) => void,
+  onError: (error: string) => void,
+): STTProvider {
+  return new LateEventSafeSTTProvider(createProvider, onTranscript, onError);
+}


### PR DESCRIPTION
## Summary

This integrates a Sandcastle-generated refactor across several app seams:

- Extracts a testable session runtime
- Deepens local app data/storage helpers
- Extracts reference card layout and entity card presentation models
- Adds Files and Voice settings category controllers
- Introduces shared world data ingestion
- Splits Deepgram browser/native capture adapters
- Adds lifecycle-safe STT wrapper behavior
- Migrates file upload and Google Docs ingestion through shared ingestion paths
- Ignores the local `.sandcastle/` work/log directory

## Validation

- [x] TypeScript: `just check`
- [x] Unit tests: `npm test`
- [x] Web build: `just build-web`
- [x] Screenshots: `just screenshot`
